### PR TITLE
Fix/27 display template

### DIFF
--- a/css/localgov-alert-banner.css
+++ b/css/localgov-alert-banner.css
@@ -1,0 +1,22 @@
+.localgov_alert_banner {
+  background-color: #fc3;
+  color: #000;
+}
+.localgov_alert_banner .wrapper {
+  margin: 0 auto;
+  max-width: 73.125rem;
+}
+.localgov_alert_banner--inner {
+  display: flex;
+  justify-content: space-between;
+  margin: 0rem 0.9375rem;
+  padding: 0.625rem 0rem;
+}
+.localgov_alert_banner--actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+}
+.localgov_alert_banner--actions .localgov_alert_banner--content-link {
+  margin-right: 0.625rem;
+}

--- a/localgov_alert_banner.libraries.yml
+++ b/localgov_alert_banner.libraries.yml
@@ -1,5 +1,8 @@
 alert_banner:
   version: VERSION
+  css:
+    layout:
+      css/localgov-alert-banner.css: {}
   js:
     js/alert_banner.js: {}
   dependencies:

--- a/localgov_alert_banner.module
+++ b/localgov_alert_banner.module
@@ -68,7 +68,7 @@ function localgov_alert_banner_entity_build_defaults_alter(array &$build, Entity
  */
 function localgov_alert_banner_preprocess(&$variables) {
 
-  if (isset($variables['elements']['localgov_alert_banner'])) {
+  if (isset($variables['elements']['#localgov_alert_banner'])) {
 
     // Get token.
     $token = \Drupal::service('localgov_alert_banner.state')->getToken();

--- a/localgov_alert_banner.page.inc
+++ b/localgov_alert_banner.page.inc
@@ -8,6 +8,7 @@
  */
 
 use Drupal\Core\Render\Element;
+use Drupal\localgov_alert_banner\Entity\AlertBannerEntity;
 
 /**
  * Prepares variables for Alert banner templates.
@@ -27,10 +28,11 @@ function template_preprocess_localgov_alert_banner(array &$variables) {
   foreach (Element::children($variables['elements']) as $key) {
     $variables['content'][$key] = $variables['elements'][$key];
   }
-  /** @var \Drupal\localgov_alert_banner\Entity\AlertBannerEntity $entity */
+  // Non-content variables
+  /** @var AlertBannerEntity $entity */
   $entity = $variables['elements']['#localgov_alert_banner'];
-  $variables['display_title'] = $entity->display_title;
-  $variables['remove_hide_link'] = $entity->remove_hide_link;
-  $variables['type_of_alert'] = $entity->type_of_alert->getString();
+  $variables['display_title'] = $entity->get('display_title');
+  $variables['remove_hide_link'] = $entity->get('remove_hide_link');
+  $variables['type_of_alert'] = $entity->get('type_of_alert')->getString();
 
 }

--- a/localgov_alert_banner.page.inc
+++ b/localgov_alert_banner.page.inc
@@ -27,4 +27,10 @@ function template_preprocess_localgov_alert_banner(array &$variables) {
   foreach (Element::children($variables['elements']) as $key) {
     $variables['content'][$key] = $variables['elements'][$key];
   }
+  /** @var \Drupal\localgov_alert_banner\Entity\AlertBannerEntity $entity */
+  $entity = $variables['elements']['#localgov_alert_banner'];
+  $variables['display_title'] = $entity->display_title->getValue();
+  $variables['remove_hide_link'] = $entity->remove_hide_link->getValue();
+  $variables['type_of_alert'] = $entity->type_of_alert->getString();
+
 }

--- a/localgov_alert_banner.page.inc
+++ b/localgov_alert_banner.page.inc
@@ -29,8 +29,8 @@ function template_preprocess_localgov_alert_banner(array &$variables) {
   }
   /** @var \Drupal\localgov_alert_banner\Entity\AlertBannerEntity $entity */
   $entity = $variables['elements']['#localgov_alert_banner'];
-  $variables['display_title'] = $entity->display_title->getValue();
-  $variables['remove_hide_link'] = $entity->remove_hide_link->getValue();
+  $variables['display_title'] = $entity->display_title;
+  $variables['remove_hide_link'] = $entity->remove_hide_link;
   $variables['type_of_alert'] = $entity->type_of_alert->getString();
 
 }

--- a/localgov_alert_banner.page.inc
+++ b/localgov_alert_banner.page.inc
@@ -8,6 +8,8 @@
  */
 
 use Drupal\Core\Render\Element;
+use Drupal\Core\Link;
+use Drupal\Core\Url;
 use Drupal\localgov_alert_banner\Entity\AlertBannerEntity;
 
 /**
@@ -28,11 +30,18 @@ function template_preprocess_localgov_alert_banner(array &$variables) {
   foreach (Element::children($variables['elements']) as $key) {
     $variables['content'][$key] = $variables['elements'][$key];
   }
-  // Non-content variables
+
   /** @var AlertBannerEntity $entity */
   $entity = $variables['elements']['#localgov_alert_banner'];
-  $variables['display_title'] = $entity->get('display_title');
-  $variables['remove_hide_link'] = $entity->get('remove_hide_link');
-  $variables['type_of_alert'] = $entity->get('type_of_alert')->getString();
+
+  // Set default link text
+  if ($entity->get('link')->title === '') {
+    $variables['content']['link'] = Link::fromTextAndUrl(t('More information'), Url::fromUri($entity->get('link')->uri))->toString();
+  }
+
+  // Non-content variables
+  $variables['display_title'] = $entity->get('display_title')->value;
+  $variables['remove_hide_link'] = $entity->get('remove_hide_link')->value;
+  $variables['type_of_alert'] = $entity->get('type_of_alert')->value;
 
 }

--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -247,11 +247,6 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
       ->setDescription(t('Show the title on the alert banner.'))
       ->setRevisionable(TRUE)
       ->setDefaultValue(1)
-      ->setDisplayOptions('view', [
-        'label' => 'above',
-        'type' => 'string',
-        'weight' => -4,
-      ])
       ->setDisplayOptions('form', [
         'type' => 'boolean_checkbox',
         'weight' => -4,
@@ -265,11 +260,6 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
       ->setDescription(t('This will remove the hide link that appears on alert banners.'))
       ->setRevisionable(TRUE)
       ->setDefaultValue(0)
-      ->setDisplayOptions('view', [
-        'label' => 'above',
-        'type' => 'string',
-        'weight' => -4,
-      ])
       ->setDisplayOptions('form', [
         'type' => 'boolean_checkbox',
         'weight' => -4,

--- a/templates/localgov_alert_banner.html.twig
+++ b/templates/localgov_alert_banner.html.twig
@@ -42,13 +42,13 @@
           <div class="localgov_alert_banner--content-link">{{ content.link }}</div>
         {% endif %}
       </div>
-      <div class="localgov_alert_banner--actions paragraph">
-        {% if not remove_hide_link %}
+      {% if not remove_hide_link %}
+      <div class="localgov_alert_banner--actions">
           <div class="localgov_alert_banner--dismiss">
             <a href="#" class="js-alert-banner-close">Hide <span class="sr-only">Notifications</span></a>
           </div>
-        {% endif %}
       </div>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/templates/localgov_alert_banner.html.twig
+++ b/templates/localgov_alert_banner.html.twig
@@ -9,14 +9,46 @@
  * Available variables:
  * - content: A list of content items. Use 'content' to print all content, or
  * - attributes: HTML attributes for the container element.
+ * - display_title: Boolean indicating if alert banner title should be displayed
+ * - remove_hide_link: Boolean indicating if the link to close the banner should be hidden
+ * - type_of_alert: Type of alert banner
  *
  * @see template_preprocess_localgov_alert_banner()
  *
  * @ingroup themeable
  */
 #}
-<div{{ attributes.addClass('localgov_alert_banner') }}>
-  {% if content %}
-    {{- content -}}
-  {% endif %}
+{{ attach_library('localgov_alert_banner/alert_banner') }}
+{%
+  set has_link = content.link is not empty
+%}
+{% set classes = [
+  'js-alert-banner',
+  'localgov_alert_banner--' ~ type_of_alert,
+  is_front ? 'localgov_alert_banner--homepage' : '',
+  has_link ? 'localgov_alert_banner--has-link' : 'localgov_alert_banner--no-link'
+] %}
+<!-- Alert Banner-->
+<div class="localgov_alert_banner" role="alert">
+  <div{{ attributes.addClass(classes) }}>
+    <div class="localgov_alert_banner--inner">
+      <div class="localgov_alert_banner--inner--content">
+        {% if display_title.value %}
+          <h2 class="localgov_alert_banner--content-heading">{{ content.title }}</h2>
+        {% endif %}
+        <p class="localgov_alert_banner--content-body">{{ content.short_description }}</p>
+      </div>
+      <div class="localgov_alert_banner--actions paragraph">
+        {% if content.link %}
+          <div class="localgov_alert_banner--content-link">{{ content.link }}</div>
+        {% endif %}
+        {% if not remove_hide_link.value %}
+          <div class="localgov_alert_banner--dismiss">
+            <a href="#" class="js-alert-banner-close">Hide <span class="sr-only">Notifications</span></a>
+          </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
 </div>
+  <!-- END Alert Banner -->

--- a/templates/localgov_alert_banner.html.twig
+++ b/templates/localgov_alert_banner.html.twig
@@ -37,7 +37,7 @@
         {% if display_title %}
           <h2 class="localgov_alert_banner--content-heading">{{ content.title }}</h2>
         {% endif %}
-        <p class="localgov_alert_banner--content-body">{{ content.short_description }}</p>
+        <div class="localgov_alert_banner--content-body">{{ content|without('link', 'title') }}</div>
         {% if content.link %}
           <div class="localgov_alert_banner--content-link">{{ content.link }}</div>
         {% endif %}

--- a/templates/localgov_alert_banner.html.twig
+++ b/templates/localgov_alert_banner.html.twig
@@ -22,13 +22,23 @@
 {%
   set has_link = content.link is not empty
 %}
-{% set classes = [
-  'wrapper',
-  'js-alert-banner',
-  'localgov_alert_banner--' ~ type_of_alert,
-  is_front ? 'localgov_alert_banner--homepage' : '',
-  has_link ? 'localgov_alert_banner--has-link' : 'localgov_alert_banner--no-link'
-] %}
+{%
+  set classes = [
+    'wrapper',
+    'js-alert-banner',
+    'localgov_alert_banner--' ~ type_of_alert,
+    is_front ? 'localgov_alert_banner--homepage' : '',
+    has_link ? 'localgov_alert_banner--has-link' : 'localgov_alert_banner--no-link'
+  ]
+%}
+{% if content.link %}
+  {% set link_url = content.link[0]['#url']  %}
+  {% if content.link[0]['#title'] == content.link[0]['#url'].toString %}
+    {% set link_title = 'More information' %}
+  {% else %}
+    {% set link_title = content.link[0]['#title'] %}
+  {% endif %}
+{% endif %}
 <!-- Alert Banner-->
 <div class="localgov_alert_banner" role="alert">
   <div{{ attributes.addClass(classes) }}>
@@ -41,7 +51,7 @@
       </div>
       <div class="localgov_alert_banner--actions paragraph">
         {% if content.link %}
-          <div class="localgov_alert_banner--content-link">{{ content.link }}</div>
+          <div class="localgov_alert_banner--content-link"><a href="{{ link_url }}">{{ link_title }}</a></div>
         {% endif %}
         {% if not remove_hide_link.value %}
           <div class="localgov_alert_banner--dismiss">

--- a/templates/localgov_alert_banner.html.twig
+++ b/templates/localgov_alert_banner.html.twig
@@ -38,11 +38,11 @@
           <h2 class="localgov_alert_banner--content-heading">{{ content.title }}</h2>
         {% endif %}
         <p class="localgov_alert_banner--content-body">{{ content.short_description }}</p>
-      </div>
-      <div class="localgov_alert_banner--actions paragraph">
         {% if content.link %}
           <div class="localgov_alert_banner--content-link">{{ content.link }}</div>
         {% endif %}
+      </div>
+      <div class="localgov_alert_banner--actions paragraph">
         {% if not remove_hide_link %}
           <div class="localgov_alert_banner--dismiss">
             <a href="#" class="js-alert-banner-close">Hide <span class="sr-only">Notifications</span></a>

--- a/templates/localgov_alert_banner.html.twig
+++ b/templates/localgov_alert_banner.html.twig
@@ -19,11 +19,9 @@
  */
 #}
 {{ attach_library('localgov_alert_banner/alert_banner') }}
-{%
-  set has_link = content.link is not empty
-%}
-{%
-  set classes = [
+{% set has_link = content.link is not empty %}
+{% set type_of_alert =  type_of_alert|split('--')[1] %}
+{% set classes = [
     'wrapper',
     'js-alert-banner',
     'localgov_alert_banner--' ~ type_of_alert,
@@ -31,29 +29,21 @@
     has_link ? 'localgov_alert_banner--has-link' : 'localgov_alert_banner--no-link'
   ]
 %}
-{% if content.link %}
-  {% set link_url = content.link[0]['#url']  %}
-  {% if content.link[0]['#title'] == content.link[0]['#url'].toString %}
-    {% set link_title = 'More information' %}
-  {% else %}
-    {% set link_title = content.link[0]['#title'] %}
-  {% endif %}
-{% endif %}
 <!-- Alert Banner-->
 <div class="localgov_alert_banner" role="alert">
   <div{{ attributes.addClass(classes) }}>
     <div class="localgov_alert_banner--inner">
       <div class="localgov_alert_banner--inner--content">
-        {% if display_title.value %}
+        {% if display_title %}
           <h2 class="localgov_alert_banner--content-heading">{{ content.title }}</h2>
         {% endif %}
         <p class="localgov_alert_banner--content-body">{{ content.short_description }}</p>
       </div>
       <div class="localgov_alert_banner--actions paragraph">
         {% if content.link %}
-          <div class="localgov_alert_banner--content-link"><a href="{{ link_url }}">{{ link_title }}</a></div>
+          <div class="localgov_alert_banner--content-link">{{ content.link }}</div>
         {% endif %}
-        {% if not remove_hide_link.value %}
+        {% if not remove_hide_link %}
           <div class="localgov_alert_banner--dismiss">
             <a href="#" class="js-alert-banner-close">Hide <span class="sr-only">Notifications</span></a>
           </div>

--- a/templates/localgov_alert_banner.html.twig
+++ b/templates/localgov_alert_banner.html.twig
@@ -23,6 +23,7 @@
   set has_link = content.link is not empty
 %}
 {% set classes = [
+  'wrapper',
   'js-alert-banner',
   'localgov_alert_banner--' ~ type_of_alert,
   is_front ? 'localgov_alert_banner--homepage' : '',

--- a/tests/src/Functional/AlertBannerBlockTest.php
+++ b/tests/src/Functional/AlertBannerBlockTest.php
@@ -54,7 +54,7 @@ class AlertBannerBlockTest extends BrowserTestBase {
   }
 
   /**
-   * Test non live alert banner does not diaplay.
+   * Test non live alert banner does not display.
    */
   public function testNonLiveAlertBannerDoesNotDisplay() {
     // Set up an alert banner.
@@ -74,6 +74,38 @@ class AlertBannerBlockTest extends BrowserTestBase {
     // (will not be flagged).
     $this->drupalGet('<front>');
     $this->assertSession()->pageTextNotContains($alert_message);
+  }
+
+  /**
+   * Test display title option.
+   */
+  public function testAlertDisplayTitle() {
+    $title = $this->randomMachineName(8);
+    $alert_message = 'Alert message: ' . $this->randomMachineName(16);
+    $alert = $this->container->get('entity_type.manager')->getStorage('localgov_alert_banner')
+      ->create([
+        'type' => 'localgov_alert_banner',
+        'title' => $title,
+        'short_description' => $alert_message,
+        'type_of_alert' => 'minor',
+        'display_title' => 1
+      ]);
+    $alert->save();
+
+    // Flag the alert banner to put it live.
+    $flag_service = $this->container->get('flag');
+    $flag = $flag_service->getFlagById('localgov_put_live');
+    $flag_service->flag($flag, $alert);
+
+    // Check title is shown when display title is true
+    $this->drupalGet('<front>');
+    $this->assertSession()->pageTextContains($title);
+
+    // Check title is not shown when display title is false
+    $alert->set('display_title', ['value' => 0]);
+    $alert->save();
+    $this->drupalGet('<front>');
+    $this->assertSession()->pageTextNotContains($title);
   }
 
 }

--- a/tests/src/Functional/AlertBannerBlockTest.php
+++ b/tests/src/Functional/AlertBannerBlockTest.php
@@ -108,4 +108,37 @@ class AlertBannerBlockTest extends BrowserTestBase {
     $this->assertSession()->pageTextNotContains($title);
   }
 
+  /**
+   * Test remove hide link option.
+   */
+  public function testAlertRemoveHideLink() {
+    $title = $this->randomMachineName(8);
+    $alert_message = 'Alert message: ' . $this->randomMachineName(16);
+    $alert = $this->container->get('entity_type.manager')->getStorage('localgov_alert_banner')
+      ->create([
+        'type' => 'localgov_alert_banner',
+        'title' => $title,
+        'short_description' => $alert_message,
+        'type_of_alert' => 'minor',
+        'remove_hide_link' => 0
+      ]);
+    $alert->save();
+
+    // Flag the alert banner to put it live.
+    $flag_service = $this->container->get('flag');
+    $flag = $flag_service->getFlagById('localgov_put_live');
+    $flag_service->flag($flag, $alert);
+
+    // Check hide link is shown when remove_hide_link is not set
+    $this->drupalGet('<front>');
+    $this->assertSession()->responseContains('js-alert-banner-close');
+    $this->assertSession()->pageTextContains('Hide');
+
+    // Check title is not shown when remove_hide_link is set
+    $alert->set('remove_hide_link', ['value' => 1]);
+    $alert->save();
+    $this->drupalGet('<front>');
+    $this->assertSession()->responseNotContains('js-alert-banner-close');
+  }
+
 }


### PR DESCRIPTION
This pull request provides a basic styled display template for alert banners #27 , and removes non-content fields from display #38 

There are several issues that emerge from this that I'm not sure about:

- Per-alert type styling - alert type keys now include weighting, if this is stable can we just use for example '20--minor' as the class to target?
- The method of defaulting to 'More information' as the link title if none is set - currently this is done in twig, would it be better in the template preprocess?
- Extraneous markup from views when rendered - how is this removed?