### PR TITLE
Replace hide link with button

### DIFF
--- a/css/localgov-alert-banner.css
+++ b/css/localgov-alert-banner.css
@@ -9,13 +9,29 @@
 .localgov_alert_banner--inner {
   display: flex;
   justify-content: space-between;
-  margin: 0rem 0.9375rem;
-  padding: 0.625rem 0rem;
+  margin: 0 0.9375rem;
+  padding: 0.625rem 0;
 }
 .localgov_alert_banner--actions {
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
+}
+.localgov_alert_banner--actions button {
+  background: #77bb55;
+  border: none;
+  color: #000;
+  font-weight: bold;
+  padding: 0.4rem 0.8rem;
+}
+.localgov_alert_banner--actions button:focus {
+  background: #410541;
+  color: #fff;
+ }
+.localgov_alert_banner--actions button:hover {
+  background: #006263;
+  color: #fff;
+  cursor: pointer;
 }
 .localgov_alert_banner--actions .localgov_alert_banner--content-link {
   margin-right: 0.625rem;

--- a/css/localgov-alert-banner.css
+++ b/css/localgov-alert-banner.css
@@ -17,22 +17,3 @@
   justify-content: space-between;
   align-items: flex-end;
 }
-.localgov_alert_banner--actions button {
-  background: #77bb55;
-  border: none;
-  color: #000;
-  font-weight: bold;
-  padding: 0.4rem 0.8rem;
-}
-.localgov_alert_banner--actions button:focus {
-  background: #410541;
-  color: #fff;
- }
-.localgov_alert_banner--actions button:hover {
-  background: #006263;
-  color: #fff;
-  cursor: pointer;
-}
-.localgov_alert_banner--actions .localgov_alert_banner--content-link {
-  margin-right: 0.625rem;
-}

--- a/js/alert_banner.js
+++ b/js/alert_banner.js
@@ -26,7 +26,7 @@
 
     $('.js-alert-banner-close').click(function(e) {
       e.preventDefault();
-      $(this).closest('.js-alert-banner').slideUp('fast');
+      $(this).closest('.js-alert-banner').attr("aria-hidden", "true").slideUp('fast');
       setAlertBannerHideCookie(token);
     });
 

--- a/templates/localgov_alert_banner.html.twig
+++ b/templates/localgov_alert_banner.html.twig
@@ -45,7 +45,7 @@
       {% if not remove_hide_link %}
       <div class="localgov_alert_banner--actions">
           <div class="localgov_alert_banner--dismiss">
-            <a href="#" class="js-alert-banner-close">Hide <span class="sr-only">Notifications</span></a>
+            <button class="js-alert-banner-close" aria-label="Hide alert">Hide</button>
           </div>
       </div>
       {% endif %}

--- a/tests/src/FunctionalJavascript/AlertBannerHideTest.php
+++ b/tests/src/FunctionalJavascript/AlertBannerHideTest.php
@@ -48,9 +48,9 @@ class AlertBannerHideTest extends WebDriverTestBase {
 
     // Find and click hide link.
     $page = $this->getSession()->getPage();
-    $link = $page->findLink('Hide');
-    $this->assertNotEmpty($link);
-    $link->click();
+    $button = $page->findButton('Hide');
+    $this->assertNotEmpty($button);
+    $button->click();
 
     // Check cookie set and banner not visible.
     $this->assertSession()->CookieExists('hide-alert-banner-token');


### PR DESCRIPTION
Closes #43:

- Replaces 'hide' link with a button element
- Adds 'aria-hidden' attribute to banner on click
- Basic styling based on Croydon
- Updated tests