### PR TITLE
Reduce permissions and add user access tests

### DIFF
--- a/config/install/user.role.emergency_publisher.yml
+++ b/config/install/user.role.emergency_publisher.yml
@@ -11,6 +11,5 @@ is_admin: null
 permissions:
   - 'access administration pages'
   - 'access localgov alert banner listing page'
-  - 'administer localgov alert banner types'
   - 'manage all localgov alert banner entities'
   - 'view all localgov alert banner entities'

--- a/config/install/user.role.emergency_publisher.yml
+++ b/config/install/user.role.emergency_publisher.yml
@@ -9,11 +9,8 @@ label: 'Emergency publisher'
 weight: -2
 is_admin: null
 permissions:
-  - 'access alert_banner entity page'
-  - 'create alert_banner entities'
-  - 'edit any alert_banner entities'
-  - 'edit own alert_banner entities'
-  - 'flag localgov_put_live'
-  - 'unflag localgov_put_live'
-  - 'view any alert_banner entities'
-  - 'view own alert_banner entities'
+  - 'access administration pages'
+  - 'access localgov alert banner listing page'
+  - 'administer localgov alert banner types'
+  - 'manage all localgov alert banner entities'
+  - 'view all localgov alert banner entities'

--- a/config/install/views.view.admin_manage_alert_banners.yml
+++ b/config/install/views.view.admin_manage_alert_banners.yml
@@ -11,8 +11,6 @@ dependencies:
   module:
     - options
     - user
-_core:
-  default_config_hash: pJmCjeC7KNRB79o3Mw2GbvGHKQy9OVCxeK1SnhuVdNU
 id: admin_manage_alert_banners
 label: 'Manage Alert Banners'
 module: views
@@ -30,7 +28,7 @@ display:
       access:
         type: perm
         options:
-          perm: 'access alert banner listing page'
+          perm: 'access localgov alert banner listing page'
       cache:
         type: tag
         options: {  }

--- a/localgov_alert_banner.permissions.yml
+++ b/localgov_alert_banner.permissions.yml
@@ -1,36 +1,22 @@
-access alert banner listing page:
+# Access the admin view at /admin/content/alert-banners
+access localgov alert banner listing page:
   title: 'View list of Alert banners'
 
-add alert banner entities:
-  title: 'Create new Alert banner entities'
-
-administer alert banner entities:
-  title: 'Administer Alert banner entities'
+# Administer alert banner bundles.
+administer localgov alert banner types:
+  title: 'Administer Alert banner types'
   description: 'Allow to access the administration form to configure Alert banner entities.'
   restrict access: true
 
-delete alert banner entities:
-  title: 'Delete Alert banner entities'
+# View all alert banners
+view all localgov alert banner entities:
+  title: 'View All alert banner entities'
 
-edit alert banner entities:
-  title: 'Edit Alert banner entities'
+# Manage all alert banners.
+manage all localgov alert banner entities:
+  title: 'Manage All alert banner entities'
+  restrict access: true
 
-view published alert banner entities:
-  title: 'View published Alert banner entities'
-
-view unpublished alert banner entities:
-  title: 'View unpublished Alert banner entities'
-
-view all alert banner revisions:
-  title: 'View all Alert banner revisions'
-
-revert all alert banner revisions:
-  title: 'Revert all Alert banner revisions'
-  description: 'Role requires permission <em>view Alert banner revisions</em> and <em>edit rights</em> for alert banner entities in question or <em>administer alert banner entities</em>.'
-
-delete all alert banner revisions:
-  title: 'Delete all revisions'
-  description: 'Role requires permission to <em>view Alert banner revisions</em> and <em>delete rights</em> for alert banner entities in question or <em>administer alert banner entities</em>.'
-
+# Per bundle permissions.
 permission_callbacks:
   - \Drupal\localgov_alert_banner\AlertBannerEntityPermissions::generatePermissions

--- a/src/Access/AlertBannerEntityPageAccess.php
+++ b/src/Access/AlertBannerEntityPageAccess.php
@@ -18,7 +18,7 @@ class AlertBannerEntityPageAccess implements AccessInterface {
    */
   public function access(AccountInterface $account) {
 
-    if ($account->hasPermission('access alert_banner entity page')) {
+    if ($account->hasPermission('access localgov alert banner entity page')) {
       return AccessResult::allowed();
     }
     else {

--- a/src/AlertBannerEntityAccessControlHandler.php
+++ b/src/AlertBannerEntityAccessControlHandler.php
@@ -20,41 +20,31 @@ class AlertBannerEntityAccessControlHandler extends EntityAccessControlHandler {
   protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
     /** @var \Drupal\localgov_alert_banner\Entity\AlertBannerEntityInterface $entity */
 
+    $entity_bundle = $entity->bundle();
+
     switch ($operation) {
 
       case 'view':
 
-        if (!$entity->isPublished()) {
-          $permission = $this->checkOwn($entity, 'view unpublished', $account);
-          if (!empty($permission)) {
-            return AccessResult::allowed();
-          }
-
-          return AccessResult::allowedIfHasPermission($account, 'view unpublished alert banner entities');
-        }
-
-        $permission = $this->checkOwn($entity, $operation, $account);
-        if (!empty($permission)) {
+        if ($account->hasPermission('view all localgov alert banner entities')) {
           return AccessResult::allowed();
         }
 
-        return AccessResult::allowedIfHasPermission($account, 'view published alert banner entities');
+        return AccessResult::allowedIfHasPermission($account, 'view localgov alert banner ' . $entity_bundle . ' entities');
 
       case 'update':
 
-        $permission = $this->checkOwn($entity, $operation, $account);
-        if (!empty($permission)) {
+        if ($account->hasPermission('manage all localgov alert banner entities')) {
           return AccessResult::allowed();
         }
-        return AccessResult::allowedIfHasPermission($account, 'edit alert banner entities');
+        return AccessResult::allowedIfHasPermission($account, 'manage localgov alert banner ' . $entity_bundle . ' entities');
 
       case 'delete':
 
-        $permission = $this->checkOwn($entity, $operation, $account);
-        if (!empty($permission)) {
+        if ($account->hasPermission('manage all localgov alert banner entities')) {
           return AccessResult::allowed();
         }
-        return AccessResult::allowedIfHasPermission($account, 'delete alert banner entities');
+        return AccessResult::allowedIfHasPermission($account, 'manage localgov alert banner ' . $entity_bundle . ' entities');
     }
 
     // Unknown operation, no opinion.
@@ -65,60 +55,10 @@ class AlertBannerEntityAccessControlHandler extends EntityAccessControlHandler {
    * {@inheritdoc}
    */
   protected function checkCreateAccess(AccountInterface $account, array $context, $entity_bundle = NULL) {
-    return AccessResult::allowedIfHasPermission($account, 'add alert banner entities');
-  }
-
-  /**
-   * Test for given 'own' permission.
-   *
-   * @param \Drupal\Core\Entity\EntityInterface $entity
-   *   Alert banner enetity.
-   * @param string $operation
-   *   Operation
-   *   - create.
-   *   - view unpublished.
-   *   - view.
-   *   - update.
-   *   - delete.
-   * @param \Drupal\Core\Session\AccountInterface $account
-   *   User account.
-   *
-   * @return string|null
-   *   The permission string indicating it's allowed.
-   */
-  protected function checkOwn(EntityInterface $entity, $operation, AccountInterface $account) {
-    $status = $entity->isPublished();
-    $uid = $entity->getOwnerId();
-
-    $is_own = $account->isAuthenticated() && $account->id() == $uid;
-    if (!$is_own) {
-      return;
+    if ($account->hasPermission('manage all localgov alert banner entities')) {
+      return AccessResult::allowed();
     }
-
-    $bundle = $entity->bundle();
-
-    $ops = [
-      'create' => '%bundle add own %bundle entities',
-      'view unpublished' => '%bundle view own unpublished %bundle entities',
-      'view' => '%bundle view own entities',
-      'update' => '%bundle edit own entities',
-      'delete' => '%bundle delete own entities',
-    ];
-    $permission = strtr($ops[$operation], ['%bundle' => $bundle]);
-
-    if ($operation === 'view unpublished') {
-      if (!$status && $account->hasPermission($permission)) {
-        return $permission;
-      }
-      else {
-        return NULL;
-      }
-    }
-    if ($account->hasPermission($permission)) {
-      return $permission;
-    }
-
-    return NULL;
+    return AccessResult::allowedIfHasPermission($account, 'manage localgov alert banner ' . $entity_bundle . ' entities');
   }
 
 }

--- a/src/AlertBannerEntityHtmlRouteProvider.php
+++ b/src/AlertBannerEntityHtmlRouteProvider.php
@@ -95,7 +95,7 @@ class AlertBannerEntityHtmlRouteProvider extends AdminHtmlRouteProvider {
           '_title' => "{$entity_type->getLabel()} revisions",
           '_controller' => '\Drupal\localgov_alert_banner\Controller\AlertBannerEntityController::revisionOverview',
         ])
-        ->setRequirement('_permission', 'manage all localgov alert banner entities')
+        ->setRequirement('_entity_access', 'localgov_alert_banner.update')
         ->setOption('_admin_route', TRUE);
 
       return $route;
@@ -119,7 +119,7 @@ class AlertBannerEntityHtmlRouteProvider extends AdminHtmlRouteProvider {
           '_controller' => '\Drupal\localgov_alert_banner\Controller\AlertBannerEntityController::revisionShow',
           '_title_callback' => '\Drupal\localgov_alert_banner\Controller\AlertBannerEntityController::revisionPageTitle',
         ])
-        ->setRequirement('_permission', 'manage all localgov alert banner entities')
+        ->setRequirement('_entity_access', 'localgov_alert_banner.update')
         ->setOption('_admin_route', TRUE);
 
       return $route;
@@ -143,7 +143,7 @@ class AlertBannerEntityHtmlRouteProvider extends AdminHtmlRouteProvider {
           '_form' => '\Drupal\localgov_alert_banner\Form\AlertBannerEntityRevisionRevertForm',
           '_title' => 'Revert to earlier revision',
         ])
-        ->setRequirement('_permission', 'manage all localgov alert banner entities')
+        ->setRequirement('_entity_access', 'localgov_alert_banner.update')
         ->setOption('_admin_route', TRUE);
 
       return $route;
@@ -167,7 +167,7 @@ class AlertBannerEntityHtmlRouteProvider extends AdminHtmlRouteProvider {
           '_form' => '\Drupal\localgov_alert_banner\Form\AlertBannerEntityRevisionDeleteForm',
           '_title' => 'Delete earlier revision',
         ])
-        ->setRequirement('_permission', 'manage all localgov alert banner entities')
+        ->setRequirement('_entity_access', 'localgov_alert_banner.update')
         ->setOption('_admin_route', TRUE);
 
       return $route;
@@ -191,7 +191,7 @@ class AlertBannerEntityHtmlRouteProvider extends AdminHtmlRouteProvider {
           '_form' => '\Drupal\localgov_alert_banner\Form\AlertBannerEntityRevisionRevertTranslationForm',
           '_title' => 'Revert to earlier revision of a translation',
         ])
-        ->setRequirement('_permission', 'manage all localgov alert banner entities')
+        ->setRequirement('_entity_access', 'localgov_alert_banner.update')
         ->setOption('_admin_route', TRUE);
 
       return $route;

--- a/src/AlertBannerEntityHtmlRouteProvider.php
+++ b/src/AlertBannerEntityHtmlRouteProvider.php
@@ -95,7 +95,7 @@ class AlertBannerEntityHtmlRouteProvider extends AdminHtmlRouteProvider {
           '_title' => "{$entity_type->getLabel()} revisions",
           '_controller' => '\Drupal\localgov_alert_banner\Controller\AlertBannerEntityController::revisionOverview',
         ])
-        ->setRequirement('_permission', 'view all alert banner revisions')
+        ->setRequirement('_permission', 'manage all localgov alert banner entities')
         ->setOption('_admin_route', TRUE);
 
       return $route;
@@ -119,7 +119,7 @@ class AlertBannerEntityHtmlRouteProvider extends AdminHtmlRouteProvider {
           '_controller' => '\Drupal\localgov_alert_banner\Controller\AlertBannerEntityController::revisionShow',
           '_title_callback' => '\Drupal\localgov_alert_banner\Controller\AlertBannerEntityController::revisionPageTitle',
         ])
-        ->setRequirement('_permission', 'view all alert banner revisions')
+        ->setRequirement('_permission', 'manage all localgov alert banner entities')
         ->setOption('_admin_route', TRUE);
 
       return $route;
@@ -143,7 +143,7 @@ class AlertBannerEntityHtmlRouteProvider extends AdminHtmlRouteProvider {
           '_form' => '\Drupal\localgov_alert_banner\Form\AlertBannerEntityRevisionRevertForm',
           '_title' => 'Revert to earlier revision',
         ])
-        ->setRequirement('_permission', 'revert all alert banner revisions')
+        ->setRequirement('_permission', 'manage all localgov alert banner entities')
         ->setOption('_admin_route', TRUE);
 
       return $route;
@@ -167,7 +167,7 @@ class AlertBannerEntityHtmlRouteProvider extends AdminHtmlRouteProvider {
           '_form' => '\Drupal\localgov_alert_banner\Form\AlertBannerEntityRevisionDeleteForm',
           '_title' => 'Delete earlier revision',
         ])
-        ->setRequirement('_permission', 'delete all alert banner revisions')
+        ->setRequirement('_permission', 'manage all localgov alert banner entities')
         ->setOption('_admin_route', TRUE);
 
       return $route;
@@ -191,7 +191,7 @@ class AlertBannerEntityHtmlRouteProvider extends AdminHtmlRouteProvider {
           '_form' => '\Drupal\localgov_alert_banner\Form\AlertBannerEntityRevisionRevertTranslationForm',
           '_title' => 'Revert to earlier revision of a translation',
         ])
-        ->setRequirement('_permission', 'revert all alert banner revisions')
+        ->setRequirement('_permission', 'manage all localgov alert banner entities')
         ->setOption('_admin_route', TRUE);
 
       return $route;

--- a/src/AlertBannerEntityPermissions.php
+++ b/src/AlertBannerEntityPermissions.php
@@ -45,32 +45,14 @@ class AlertBannerEntityPermissions {
     $type_params = ['%type_name' => $type->label()];
 
     return [
-      "$type_id create entities" => [
-        'title' => $this->t('Create new %type_name entities', $type_params),
+      // View alert banner entities of type.
+      "localgov alert banner $type_id view entities" => [
+        'title' => $this->t('View alert banner entities of type %type_name', $type_params),
       ],
-      "$type_id edit own entities" => [
-        'title' => $this->t('Edit own %type_name entities', $type_params),
-      ],
-      "$type_id edit any entities" => [
-        'title' => $this->t('Edit any %type_name entities', $type_params),
-      ],
-      "$type_id delete own entities" => [
-        'title' => $this->t('Delete own %type_name entities', $type_params),
-      ],
-      "$type_id delete any entities" => [
-        'title' => $this->t('Delete any %type_name entities', $type_params),
-      ],
-      "$type_id view revisions" => [
-        'title' => $this->t('View %type_name revisions', $type_params),
-        'description' => $this->t('To view a revision, you also need permission to view the entity item.'),
-      ],
-      "$type_id revert revisions" => [
-        'title' => $this->t('Revert %type_name revisions', $type_params),
-        'description' => $this->t('To revert a revision, you also need permission to edit the entity item.'),
-      ],
-      "$type_id delete revisions" => [
-        'title' => $this->t('Delete %type_name revisions', $type_params),
-        'description' => $this->t('To delete a revision, you also need permission to delete the entity item.'),
+
+      // Manage the alert banner of type (full CRUD permissions).
+      "manange localgov alert banner $type_id entities" => [
+        'title' => $this->t('Manage alert banner entities of type %type_name', $type_params),
       ],
     ];
   }

--- a/src/AlertBannerEntityPermissions.php
+++ b/src/AlertBannerEntityPermissions.php
@@ -46,12 +46,12 @@ class AlertBannerEntityPermissions {
 
     return [
       // View alert banner entities of type.
-      "localgov alert banner $type_id view entities" => [
+      "view localgov alert banner $type_id entities" => [
         'title' => $this->t('View alert banner entities of type %type_name', $type_params),
       ],
 
       // Manage the alert banner of type (full CRUD permissions).
-      "manange localgov alert banner $type_id entities" => [
+      "manage localgov alert banner $type_id entities" => [
         'title' => $this->t('Manage alert banner entities of type %type_name', $type_params),
       ],
     ];

--- a/src/Controller/AlertBannerEntityController.php
+++ b/src/Controller/AlertBannerEntityController.php
@@ -77,7 +77,7 @@ class AlertBannerEntityController extends ControllerBase implements ContainerInj
   }
 
   /**
-   * Generates an overview table of older revisions of a Alert banner.
+   * Generates an overview table of older revisions of an Alert banner.
    *
    * @param \Drupal\localgov_alert_banner\Entity\AlertBannerEntityInterface $localgov_alert_banner
    *   A Alert banner object.
@@ -92,12 +92,13 @@ class AlertBannerEntityController extends ControllerBase implements ContainerInj
     $langcode = $localgov_alert_banner->language()->getId();
     $langname = $localgov_alert_banner->language()->getName();
     $languages = $localgov_alert_banner->getTranslationLanguages();
+    $type_id = $localgov_alert_banner->getType();
     $has_translations = (count($languages) > 1);
     $build['#title'] = $has_translations ? $this->t('@langname revisions for %title', ['@langname' => $langname, '%title' => $localgov_alert_banner->label()]) : $this->t('Revisions for %title', ['%title' => $localgov_alert_banner->label()]);
 
     $header = [$this->t('Revision'), $this->t('Operations')];
-    $revert_permission = (($account->hasPermission("revert all alert banner revisions") || $account->hasPermission('administer alert banner entities')));
-    $delete_permission = (($account->hasPermission("delete all alert banner revisions") || $account->hasPermission('administer alert banner entities')));
+    $revert_permission = (($account->hasPermission("manage all localgov alert banner entities") || $account->hasPermission('manage localgov alert banner ' . $type_id . ' entities')));
+    $delete_permission = (($account->hasPermission("manage all localgov alert banner entities") || $account->hasPermission('manage localgov alert banner ' . $type_id . ' entities')));
 
     $rows = [];
 

--- a/src/Controller/AlertBannerEntityController.php
+++ b/src/Controller/AlertBannerEntityController.php
@@ -92,7 +92,7 @@ class AlertBannerEntityController extends ControllerBase implements ContainerInj
     $langcode = $localgov_alert_banner->language()->getId();
     $langname = $localgov_alert_banner->language()->getName();
     $languages = $localgov_alert_banner->getTranslationLanguages();
-    $type_id = $localgov_alert_banner->getType();
+    $type_id = $localgov_alert_banner->bundle();
     $has_translations = (count($languages) > 1);
     $build['#title'] = $has_translations ? $this->t('@langname revisions for %title', ['@langname' => $langname, '%title' => $localgov_alert_banner->label()]) : $this->t('Revisions for %title', ['%title' => $localgov_alert_banner->label()]);
 

--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -44,7 +44,7 @@ use Drupal\user\UserInterface;
  *   revision_data_table = "localgov_alert_banner_field_revision",
  *   translatable = TRUE,
  *   permission_granularity = "bundle",
- *   admin_permission = "administer alert banner entities",
+ *   admin_permission = "manage all localgov alert banner entities",
  *   entity_keys = {
  *     "id" = "id",
  *     "revision" = "vid",

--- a/src/Entity/AlertBannerEntityType.php
+++ b/src/Entity/AlertBannerEntityType.php
@@ -23,7 +23,7 @@ use Drupal\Core\Config\Entity\ConfigEntityBundleBase;
  *     },
  *   },
  *   config_prefix = "localgov_alert_banner_type",
- *   admin_permission = "administer site configuration",
+ *   admin_permission = "administer localgov alert banner types",
  *   bundle_of = "localgov_alert_banner",
  *   entity_keys = {
  *     "id" = "id",

--- a/tests/src/Functional/PermissionsTest.php
+++ b/tests/src/Functional/PermissionsTest.php
@@ -50,15 +50,15 @@ class PermissionsTest extends BrowserTestBase {
   public function testAlertBannerUserAccess() {
 
     // Check that anonymous user cannot access to the overview page
-    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner');
-    // @TODO alert banner new admin view.
-    // $this->drupalGet('admin/content/alert-banners');
+    $this->drupalGet('admin/content/alert-banners');
     $this->assertResponse(Response::HTTP_FORBIDDEN);
 
     // Check that anonymous user does not have CRUD page access
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/add/localgov_alert_banner');
     $this->assertResponse(Response::HTTP_FORBIDDEN);
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1/edit');
+    $this->assertResponse(Response::HTTP_FORBIDDEN);
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1/revisions');
     $this->assertResponse(Response::HTTP_FORBIDDEN);
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1/delete');
     $this->assertResponse(Response::HTTP_FORBIDDEN);
@@ -71,15 +71,15 @@ class PermissionsTest extends BrowserTestBase {
     $this->drupalLogin($normalAdminUser);
 
     // Check that authenticated user cannot access to the overview page
-    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner');
-    // @TODO alert banner new admin view.
-    // $this->drupalGet('admin/content/alert-banners');
+    $this->drupalGet('admin/content/alert-banners');
     $this->assertResponse(Response::HTTP_FORBIDDEN);
 
     // Check that authenticated user does not have CRUD page access
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/add/localgov_alert_banner');
     $this->assertResponse(Response::HTTP_FORBIDDEN);
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1/edit');
+    $this->assertResponse(Response::HTTP_FORBIDDEN);
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1/revisions');
     $this->assertResponse(Response::HTTP_FORBIDDEN);
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1/delete');
     $this->assertResponse(Response::HTTP_FORBIDDEN);
@@ -93,15 +93,15 @@ class PermissionsTest extends BrowserTestBase {
     $this->drupalLogin($emergencyPublisherUser);
 
     // Check that emergency publisher user has access to the overview page
-    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner');
-    // @TODO alert banner new admin view.
-    // $this->drupalGet('admin/content/alert-banners');
+    $this->drupalGet('admin/content/alert-banners');
     $this->assertResponse(Response::HTTP_OK);
 
     // Check that emergency publisher user has CRUD page access
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/add/localgov_alert_banner');
     $this->assertResponse(Response::HTTP_OK);
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1/edit');
+    $this->assertResponse(Response::HTTP_OK);
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1/revisions');
     $this->assertResponse(Response::HTTP_OK);
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1/delete');
     $this->assertResponse(Response::HTTP_OK);

--- a/tests/src/Functional/PermissionsTest.php
+++ b/tests/src/Functional/PermissionsTest.php
@@ -49,11 +49,11 @@ class PermissionsTest extends BrowserTestBase {
    */
   public function testAlertBannerUserAccess() {
 
-    // Check that anonymous user cannot access to the overview page
+    // Check that anonymous user cannot access to the overview page.
     $this->drupalGet('admin/content/alert-banners');
     $this->assertResponse(Response::HTTP_FORBIDDEN);
 
-    // Check that anonymous user does not have CRUD page access
+    // Check that anonymous user does not have CRUD page access.
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/add/localgov_alert_banner');
     $this->assertResponse(Response::HTTP_FORBIDDEN);
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1/edit');
@@ -74,11 +74,11 @@ class PermissionsTest extends BrowserTestBase {
     $normalAdminUser = $this->createUser(['access administration pages']);
     $this->drupalLogin($normalAdminUser);
 
-    // Check that authenticated user cannot access to the overview page
+    // Check that authenticated user cannot access to the overview page.
     $this->drupalGet('admin/content/alert-banners');
     $this->assertResponse(Response::HTTP_FORBIDDEN);
 
-    // Check that authenticated user does not have CRUD page access
+    // Check that authenticated user does not have CRUD page access.
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/add/localgov_alert_banner');
     $this->assertResponse(Response::HTTP_FORBIDDEN);
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1/edit');
@@ -103,11 +103,11 @@ class PermissionsTest extends BrowserTestBase {
     $emergencyPublisherUser->save();
     $this->drupalLogin($emergencyPublisherUser);
 
-    // Check that emergency publisher user has access to the overview page
+    // Check that emergency publisher user has access to the overview page.
     $this->drupalGet('admin/content/alert-banners');
     $this->assertResponse(Response::HTTP_OK);
 
-    // Check that emergency publisher user has CRUD page access
+    // Check that emergency publisher user has CRUD page access.
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/add/localgov_alert_banner');
     $this->assertResponse(Response::HTTP_OK);
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1/edit');
@@ -136,11 +136,11 @@ class PermissionsTest extends BrowserTestBase {
     ]);
     $this->drupalLogin($bannerUser);
 
-    // Check that emergency publisher user has access to the overview page
+    // Check that emergency publisher user has access to the overview page.
     $this->drupalGet('admin/content/alert-banners');
     $this->assertResponse(Response::HTTP_OK);
 
-    // Check that emergency publisher user has CRUD page access
+    // Check that emergency publisher user has CRUD page access.
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/add/localgov_alert_banner');
     $this->assertResponse(Response::HTTP_OK);
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1/edit');

--- a/tests/src/Functional/PermissionsTest.php
+++ b/tests/src/Functional/PermissionsTest.php
@@ -88,8 +88,11 @@ class PermissionsTest extends BrowserTestBase {
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1');
     $this->assertResponse(Response::HTTP_FORBIDDEN);
 
+    $this->drupalLogout();
+
     $emergencyPublisherUser = $this->createUser();
     $emergencyPublisherUser->addRole('emergency_publisher');
+    $emergencyPublisherUser->save();
     $this->drupalLogin($emergencyPublisherUser);
 
     // Check that emergency publisher user has access to the overview page

--- a/tests/src/Functional/PermissionsTest.php
+++ b/tests/src/Functional/PermissionsTest.php
@@ -113,6 +113,34 @@ class PermissionsTest extends BrowserTestBase {
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1');
     $this->assertResponse(Response::HTTP_OK);
 
+    $this->drupalLogout();
+
+    // Test a user with only the per banner permissions.
+    $bannerUser = $this->createUser([
+      'access administration pages',
+      'access localgov alert banner listing page',
+      'manage localgov alert banner localgov_alert_banner entities',
+      'view localgov alert banner localgov_alert_banner entities',
+    ]);
+    $this->drupalLogin($bannerUser);
+
+    // Check that emergency publisher user has access to the overview page
+    $this->drupalGet('admin/content/alert-banners');
+    $this->assertResponse(Response::HTTP_OK);
+
+    // Check that emergency publisher user has CRUD page access
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/add/localgov_alert_banner');
+    $this->assertResponse(Response::HTTP_OK);
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1/edit');
+    $this->assertResponse(Response::HTTP_OK);
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1/revisions');
+    $this->assertResponse(Response::HTTP_OK);
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1/delete');
+    $this->assertResponse(Response::HTTP_OK);
+
+    // Check that emergency publisher user can view the alert banner main page.
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1');
+    $this->assertResponse(Response::HTTP_OK);
   }
 
 }

--- a/tests/src/Functional/PermissionsTest.php
+++ b/tests/src/Functional/PermissionsTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Drupal\Tests\localgov_alert_banner\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Functional tests for LocalGovDrupal Alert banner block.
+ */
+class PermissionsTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $profile = 'localgov';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'localgov_alert_banner',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+
+    parent::setUp();
+
+    // Set up an alert banner.
+    $title = $this->randomMachineName(8);
+    $alert_message = 'Alert message: ' . $this->randomMachineName(16);
+    $alert = $this->container->get('entity_type.manager')->getStorage('localgov_alert_banner')
+      ->create([
+        'type' => 'localgov_alert_banner',
+        'title' => $title,
+        'short_description' => $alert_message,
+        'type_of_alert' => 'minor',
+        // 'link' => 'https://localgovdrupal.org/'.
+      ]);
+    $alert->save();
+
+  }
+
+  /**
+   * Test the alert banner user access permissions.
+   */
+  public function testAlertBannerUserAccess() {
+
+    // Check that anonymous user cannot access to the overview page
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner');
+    // @TODO alert banner new admin view.
+    // $this->drupalGet('admin/content/alert-banners');
+    $this->assertResponse(Response::HTTP_FORBIDDEN);
+
+    // Check that anonymous user does not have CRUD page access
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/add/localgov_alert_banner');
+    $this->assertResponse(Response::HTTP_FORBIDDEN);
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1/edit');
+    $this->assertResponse(Response::HTTP_FORBIDDEN);
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1/delete');
+    $this->assertResponse(Response::HTTP_FORBIDDEN);
+
+    // Check that anonymous user cannot view the alert banner main page.
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1');
+    $this->assertResponse(Response::HTTP_FORBIDDEN);
+
+    $normalAdminUser = $this->createUser(['access administration pages']);
+    $this->drupalLogin($normalAdminUser);
+
+    // Check that authenticated user cannot access to the overview page
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner');
+    // @TODO alert banner new admin view.
+    // $this->drupalGet('admin/content/alert-banners');
+    $this->assertResponse(Response::HTTP_FORBIDDEN);
+
+    // Check that authenticated user does not have CRUD page access
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/add/localgov_alert_banner');
+    $this->assertResponse(Response::HTTP_FORBIDDEN);
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1/edit');
+    $this->assertResponse(Response::HTTP_FORBIDDEN);
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1/delete');
+    $this->assertResponse(Response::HTTP_FORBIDDEN);
+
+    // Check that authenticated user cannot view the alert banner main page.
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1');
+    $this->assertResponse(Response::HTTP_FORBIDDEN);
+
+    $emergencyPublisherUser = $this->createUser();
+    $emergencyPublisherUser->addRole('emergency_publisher');
+    $this->drupalLogin($emergencyPublisherUser);
+
+    // Check that emergency publisher user has access to the overview page
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner');
+    // @TODO alert banner new admin view.
+    // $this->drupalGet('admin/content/alert-banners');
+    $this->assertResponse(Response::HTTP_OK);
+
+    // Check that emergency publisher user has CRUD page access
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/add/localgov_alert_banner');
+    $this->assertResponse(Response::HTTP_OK);
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1/edit');
+    $this->assertResponse(Response::HTTP_OK);
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1/delete');
+    $this->assertResponse(Response::HTTP_OK);
+
+    // Check that emergency publisher user can view the alert banner main page.
+    $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1');
+    $this->assertResponse(Response::HTTP_OK);
+
+  }
+
+}

--- a/tests/src/Functional/PermissionsTest.php
+++ b/tests/src/Functional/PermissionsTest.php
@@ -67,6 +67,10 @@ class PermissionsTest extends BrowserTestBase {
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1');
     $this->assertResponse(Response::HTTP_FORBIDDEN);
 
+    // Check that anonymous user cannot access the alert banner types.
+    $this->drupalGet('admin/structure/alert-banner-types/localgov_alert_banner_type');
+    $this->assertResponse(Response::HTTP_FORBIDDEN);
+
     $normalAdminUser = $this->createUser(['access administration pages']);
     $this->drupalLogin($normalAdminUser);
 
@@ -86,6 +90,10 @@ class PermissionsTest extends BrowserTestBase {
 
     // Check that authenticated user cannot view the alert banner main page.
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1');
+    $this->assertResponse(Response::HTTP_FORBIDDEN);
+
+    // Check that authenticated user cannot access the alert banner types.
+    $this->drupalGet('admin/structure/alert-banner-types/localgov_alert_banner_type');
     $this->assertResponse(Response::HTTP_FORBIDDEN);
 
     $this->drupalLogout();
@@ -112,6 +120,10 @@ class PermissionsTest extends BrowserTestBase {
     // Check that emergency publisher user can view the alert banner main page.
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1');
     $this->assertResponse(Response::HTTP_OK);
+
+    // Check that emergency publisher user cannot access the alert banner types.
+    $this->drupalGet('admin/structure/alert-banner-types/localgov_alert_banner_type');
+    $this->assertResponse(Response::HTTP_FORBIDDEN);
 
     $this->drupalLogout();
 
@@ -140,6 +152,19 @@ class PermissionsTest extends BrowserTestBase {
 
     // Check that emergency publisher user can view the alert banner main page.
     $this->drupalGet('admin/content/alert-banner/localgov_alert_banner/1');
+    $this->assertResponse(Response::HTTP_OK);
+
+    $this->drupalLogout();
+
+    // Test an admin user can access the alert banner types.
+    $adminUser = $this->createUser([
+      'access administration pages',
+      'administer localgov alert banner types',
+    ]);
+    $this->drupalLogin($adminUser);
+
+    // Check that the admin user can access the alert banner types.
+    $this->drupalGet('admin/structure/alert-banner-types/localgov_alert_banner_type');
     $this->assertResponse(Response::HTTP_OK);
   }
 


### PR DESCRIPTION
Fix #39

This reduces the permissions to 
- access localgov alert banner listing page
- administer localgov alert banner types (Create and manage bundles)
- view all localgov alert banner entities
- manage all localgov alert banner entities
- Per bundle versions of 
  - view localgov alert banner $type_id entities
  - manage localgov alert banner $type_id entities

Adds test which checks access control for anon, authenticated, 
emergency publisher, a user with access to one alert banner bundle and
an administrator user who can edit banner types.