### PR TITLE
Basic styling for default alert types

### DIFF
--- a/css/localgov-alert-banner.css
+++ b/css/localgov-alert-banner.css
@@ -1,7 +1,44 @@
+/**
+ * @file
+ * Style rules for alert banners
+ */
+
+/* Default */
 .localgov_alert_banner {
-  background-color: #fc3;
-  color: #000;
+  background-color: #00856A;
 }
+.localgov_alert_banner,
+.localgov_alert_banner a {
+  color: #fefefe;
+}
+.localgov_alert_banner button {
+  color: #121212;
+}
+
+/* Announcement */
+.localgov_alert_banner--announcement {
+  background-color: #00856A;
+}
+
+/* Minor */
+.localgov_alert_banner--minor {
+  background-color: #fc3;
+  color: #121212;
+}
+.localgov_alert_banner--minor a {
+  color: #121212;
+}
+
+/* Major */
+.localgov_alert_banner--major {
+  background-color: #C00010;
+}
+
+/* Death of a notable person */
+.localgov_alert_banner--notable-person {
+  background-color: #000;
+}
+
 .localgov_alert_banner .wrapper {
   margin: 0 auto;
   max-width: 73.125rem;

--- a/templates/localgov_alert_banner.html.twig
+++ b/templates/localgov_alert_banner.html.twig
@@ -22,7 +22,7 @@
 {% set has_link = content.link is not empty %}
 {% set type_of_alert =  type_of_alert|split('--')[1] %}
 {% set classes = [
-    'wrapper',
+    'localgov_alert_banner',
     'js-alert-banner',
     type_of_alert ? 'localgov_alert_banner--' ~ type_of_alert : '',
     is_front ? 'localgov_alert_banner--homepage' : '',
@@ -30,8 +30,8 @@
   ]
 %}
 <!-- Alert Banner-->
-<div class="localgov_alert_banner" role="alert">
-  <div{{ attributes.addClass(classes) }}>
+<div {{ attributes.addClass(classes) }} role="alert">
+  <div class="wrapper">
     <div class="localgov_alert_banner--inner">
       <div class="localgov_alert_banner--inner--content">
         {% if display_title %}


### PR DESCRIPTION
This PR provides basic styling for each of the default alert types, based on [GDS examples](https://docs.publishing.service.gov.uk/manual/emergency-publishing.html#death-of-a-notable-person). It also makes a minor adjustment to the template to move type classes to the parent div.

Styles display as:

<img width="1003" alt="announcement" src="https://user-images.githubusercontent.com/261421/87139649-3c420a80-c298-11ea-8703-29b6731049b0.png">
<img width="1003" alt="minor" src="https://user-images.githubusercontent.com/261421/87139657-406e2800-c298-11ea-9561-d16354221aca.png">
<img width="1003" alt="major" src="https://user-images.githubusercontent.com/261421/87139665-4237eb80-c298-11ea-83ac-bff0b5112526.png">
<img width="1000" alt="death" src="https://user-images.githubusercontent.com/261421/87139673-4401af00-c298-11ea-8bff-9009e6ca77d0.png">


