### PR TITLE
Redirect to confirmation step when changing state on the form

### DIFF
--- a/localgov_alert_banner.info.yml
+++ b/localgov_alert_banner.info.yml
@@ -8,6 +8,7 @@ dependencies:
   - drupal:field
   - drupal:field_group
   - drupal:link
+  - drupal:node
   - drupal:options
   - drupal:user
   - drupal:views

--- a/src/Form/AlertBannerEntityForm.php
+++ b/src/Form/AlertBannerEntityForm.php
@@ -36,6 +36,13 @@ class AlertBannerEntityForm extends ContentEntityForm {
   protected $configFactory;
 
   /**
+   * Request stack service.
+   *
+   * @var Symfony\Component\HttpFoundation\Request
+   */
+  protected $request;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
@@ -44,6 +51,7 @@ class AlertBannerEntityForm extends ContentEntityForm {
     $instance->account = $container->get('current_user');
     $instance->moduleHandler = $container->get('module_handler');
     $instance->configFactory = $container->get('config.factory');
+    $instance->request = $container->get('request_stack');
     return $instance;
   }
 
@@ -198,7 +206,10 @@ class AlertBannerEntityForm extends ContentEntityForm {
     }
 
     if ($form_state->getValue('status-change') == TRUE) {
-      $form_state->setRedirect('entity.localgov_alert_banner.status_form', ['localgov_alert_banner' => $entity->id()]);
+      // Remove destination query and pass it through to the confirmation form.
+      $destination = $this->request->getCurrentRequest()->query->get('destination');
+      $this->request->getCurrentRequest()->query->remove('destination');
+      $form_state->setRedirect('entity.localgov_alert_banner.status_form', ['localgov_alert_banner' => $entity->id()], ['query' => ['destination' => $destination]]);
     }
     else {
       $form_state->setRedirect('entity.localgov_alert_banner.collection', ['localgov_alert_banner' => $entity->id()]);

--- a/src/Form/AlertBannerEntityForm.php
+++ b/src/Form/AlertBannerEntityForm.php
@@ -4,6 +4,7 @@ namespace Drupal\localgov_alert_banner\Form;
 
 use Drupal\Core\Entity\ContentEntityForm;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\localgov_alert_banner\Entity\AlertBannerEntity;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -50,10 +51,11 @@ class AlertBannerEntityForm extends ContentEntityForm {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    /* @var \Drupal\localgov_alert_banner\Entity\AlertBannerEntity $entity */
     $form = parent::buildForm($form, $form_state);
+    $entity = $this->entity;
+    assert($entity instanceof AlertBannerEntity);
 
-    if (!$this->entity->isNew()) {
+    if (!$entity->isNew()) {
       $form['new_revision'] = [
         '#type' => 'checkbox',
         '#title' => $this->t('Create new revision'),
@@ -137,9 +139,27 @@ class AlertBannerEntityForm extends ContentEntityForm {
     // Move publishing options into sidebar like nodes.
     $form['display_title']['#group'] = 'publishing_options';
     $form['remove_hide_link']['#group'] = 'publishing_options';
-    // TODO Follow up action confirmation of publishing and
-    // unset($form['status']); or similar.
-    $form['status']['#group'] = 'publishing_options';
+    // Status.
+    unset($form['status']);
+    if ($entity->isNew()) {
+      $status_message = $this->t('New %type', ['%type' => $entity->getEntityType()->getLabel()]);
+    }
+    elseif ($entity->isPublished()) {
+      $status_message = $this->t('Live %type', ['%type' => $entity->getEntityType()->getLabel()]);
+    }
+    else {
+      $status_message = $this->t('Stored %type', ['%type' => $entity->getEntityType()->getLabel()]);
+    }
+    $form['publishing_options']['status-message'] = [
+      '#type' => 'markup',
+      '#markup' => $status_message,
+      '#weight' => -10,
+    ];
+    $form['publishing_options']['status-change'] = [
+      '#type' => 'checkbox',
+      '#title' => $entity->isPublished() ? $this->t('Remove') : $this->t('Set live'),
+      '#description' => $this->t('On submission proceed to confirmation form to change the live status.'),
+    ];
 
     return $form;
   }
@@ -176,7 +196,13 @@ class AlertBannerEntityForm extends ContentEntityForm {
           '%label' => $entity->label(),
         ]));
     }
-    $form_state->setRedirect('entity.localgov_alert_banner.canonical', ['localgov_alert_banner' => $entity->id()]);
+
+    if ($form_state->getValue('status-change') == TRUE) {
+      $form_state->setRedirect('entity.localgov_alert_banner.status_form', ['localgov_alert_banner' => $entity->id()]);
+    }
+    else {
+      $form_state->setRedirect('entity.localgov_alert_banner.collection', ['localgov_alert_banner' => $entity->id()]);
+    }
   }
 
 }

--- a/src/Form/AlertBannerEntityStatusForm.php
+++ b/src/Form/AlertBannerEntityStatusForm.php
@@ -81,6 +81,8 @@ class AlertBannerEntityStatusForm extends ContentEntityConfirmFormBase {
     $message = $this->getStatusChangedMessage();
     $this->messenger()->addStatus($message);
     $this->logStatusChanged();
+
+    $form_state->setRedirect('entity.localgov_alert_banner.collection', ['localgov_alert_banner' => $entity->id()]);
   }
 
   /**

--- a/tests/src/Functional/AlertConfirmationTest.php
+++ b/tests/src/Functional/AlertConfirmationTest.php
@@ -107,8 +107,8 @@ class AlertConfirmationTest extends BrowserTestBase {
     $this->assertSession()->addressEquals($alert->toUrl('status-form')->toString());
     $this->getSession()->getPage()->pressButton('Confirm');
 
-    // Do not change the banner state and verify that is does not go to the
-    // confirmation page.
+    // Do not change the banner state and verify that user is not redirected to
+    // the confirmation form page.
     $edit_url = $alert->toUrl('edit-form')->toString();
     $form_vars = [
       'status-change' => 0,

--- a/tests/src/Functional/AlertConfirmationTest.php
+++ b/tests/src/Functional/AlertConfirmationTest.php
@@ -63,6 +63,7 @@ class AlertConfirmationTest extends BrowserTestBase {
     $this->getSession()->getPage()->pressButton('Confirm');
     $this->assertSession()->pageTextContains('The alert banner ' . $title . ' has been set live');
 
+    $this->drupalGet($alert->toUrl('canonical')->toString());
     $this->clickLink('Remove banner');
     $this->assertSession()->addressEquals($alert->toUrl('status-form')->toString());
     $this->assertSession()->pageTextContains('Remove current alert banner ' . $title);


### PR DESCRIPTION
Ref #70

When user saves an alert banner and the state is changed, users get redirected
to the confirmation step.
This occurs even if there is a destination paremeter.