### PR TITLE
Remove flag from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
     "homepage": "https://github.com/localgovdrupal/localgov_alert_banner",
     "minimum-stability": "dev",
     "require": {
-        "drupal/field_group": "~3.1",
-        "drupal/flag": "^4.0@beta"
+        "drupal/field_group": "~3.1"
     }
 }


### PR DESCRIPTION
Fix #73

As flag is no longer a dependancy, no need to install it.