### PR TITLE
Rename the admin view to localgov_admin_manage_alert_banners

### DIFF
--- a/config/install/views.view.localgov_admin_manage_alert_banners.yml
+++ b/config/install/views.view.localgov_admin_manage_alert_banners.yml
@@ -12,7 +12,7 @@ dependencies:
     - localgov_alert_banner
     - options
     - user
-id: admin_manage_alert_banners
+id: localgov_admin_manage_alert_banners
 label: 'Manage Alert Banners'
 module: views
 description: ''

--- a/localgov_alert_banner.links.action.yml
+++ b/localgov_alert_banner.links.action.yml
@@ -3,7 +3,7 @@ entity.localgov_alert_banner.add_form:
   title: 'Add Alert banner'
   appears_on:
     - entity.localgov_alert_banner.collection
-    - view.admin_manage_alert_banners.localgov_alert_banner_admin_list
+    - view.localgov_admin_manage_alert_banners.localgov_alert_banner_admin_list
 entity.localgov_alert_banner_type.add_form:
   route_name: entity.localgov_alert_banner_type.add_form
   title: 'Add Alert banner type'


### PR DESCRIPTION
Fix #75

Renames the admin view to make sure it uses the correct namespace
Does not apply to the display view as that will be converted to a block