### PR TITLE
Follow up change from #86

### DIFF
--- a/src/Form/AlertBannerEntityRevisionRevertForm.php
+++ b/src/Form/AlertBannerEntityRevisionRevertForm.php
@@ -37,12 +37,20 @@ class AlertBannerEntityRevisionRevertForm extends ConfirmFormBase {
   protected $dateFormatter;
 
   /**
+   * The time service.
+   *
+   * @var \Drupal\Component\Datetime\TimeInterface
+   */
+  protected $dateTime;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
     $instance = parent::create($container);
     $instance->alertBannerEntityStorage = $container->get('entity_type.manager')->getStorage('localgov_alert_banner');
     $instance->dateFormatter = $container->get('date.formatter');
+    $instance->dateTime = $container->get('datetime.time');
     return $instance;
   }
 
@@ -107,8 +115,14 @@ class AlertBannerEntityRevisionRevertForm extends ConfirmFormBase {
     ]);
     $this->revision->save();
 
-    $this->logger('content')->notice('Alert banner: reverted %title revision %revision.', ['%title' => $this->revision->label(), '%revision' => $this->revision->getRevisionId()]);
-    $this->messenger()->addMessage($this->t('Alert banner %title has been reverted to the revision from %revision-date.', ['%title' => $this->revision->label(), '%revision-date' => $this->dateFormatter->format($original_revision_timestamp)]));
+    $this->logger('content')->notice('Alert banner: reverted %title revision %revision.', [
+      '%title' => $this->revision->label(),
+      '%revision' => $this->revision->getRevisionId(),
+    ]);
+    $this->messenger()->addMessage($this->t('Alert banner %title has been reverted to the revision from %revision-date.', [
+      '%title' => $this->revision->label(),
+      '%revision-date' => $this->dateFormatter->format($original_revision_timestamp),
+    ]));
     $form_state->setRedirect(
       'entity.localgov_alert_banner.version_history',
       ['localgov_alert_banner' => $this->revision->id()]
@@ -129,7 +143,7 @@ class AlertBannerEntityRevisionRevertForm extends ConfirmFormBase {
   protected function prepareRevertedRevision(AlertBannerEntityInterface $revision, FormStateInterface $form_state) {
     $revision->setNewRevision();
     $revision->isDefaultRevision(TRUE);
-    $revision->setRevisionCreationTime(\Drupal::time()->getRequestTime());
+    $revision->setRevisionCreationTime($this->dateTime->getRequestTime());
 
     return $revision;
   }

--- a/src/Form/AlertBannerEntityRevisionRevertTranslationForm.php
+++ b/src/Form/AlertBannerEntityRevisionRevertTranslationForm.php
@@ -28,11 +28,19 @@ class AlertBannerEntityRevisionRevertTranslationForm extends AlertBannerEntityRe
   protected $languageManager;
 
   /**
+   * The time service.
+   *
+   * @var \Drupal\Component\Datetime\TimeInterface
+   */
+  protected $dateTime;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
     $instance = parent::create($container);
     $instance->languageManager = $container->get('language_manager');
+    $instance->dateTime = $container->get('datetime.time');
     return $instance;
   }
 
@@ -89,7 +97,7 @@ class AlertBannerEntityRevisionRevertTranslationForm extends AlertBannerEntityRe
 
     $latest_revision_translation->setNewRevision();
     $latest_revision_translation->isDefaultRevision(TRUE);
-    $revision->setRevisionCreationTime(\Drupal::time()->getRequestTime());
+    $revision->setRevisionCreationTime($this->dateTime->getRequestTime());
 
     return $latest_revision_translation;
   }


### PR DESCRIPTION
Replacing \Drupal::time() with Dependency injection-based equivalent.

Also fixed another coding standard issue spotted by drupal/coder:8.3.10