### PR TITLE
Fix for typo in the label for announcement type

### DIFF
--- a/config/install/field.storage.localgov_alert_banner.type_of_alert.yml
+++ b/config/install/field.storage.localgov_alert_banner.type_of_alert.yml
@@ -14,7 +14,7 @@ settings:
   allowed_values:
     -
       value: 00--announcement
-      label: Annoucement
+      label: Announcement
     -
       value: 20--minor
       label: 'Minor alert'


### PR DESCRIPTION
A not so significant change :)

Spotted it while setting up the Croydon site.