### PR TITLE
Remove tests dependancy on localgov_profile

### DIFF
--- a/tests/src/Functional/AlertBannerBlockTest.php
+++ b/tests/src/Functional/AlertBannerBlockTest.php
@@ -12,19 +12,36 @@ class AlertBannerBlockTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected $defaultTheme = 'localgov_theme';
-
-  /**
-   * {@inheritdoc}
-   */
-  protected $profile = 'localgov';
+  protected $defaultTheme = 'classy';
 
   /**
    * {@inheritdoc}
    */
   public static $modules = [
+    'block',
+    'path',
+    'options',
     'localgov_alert_banner',
   ];
+
+  /**
+   * A user with the 'administer blocks' permission.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $adminUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->adminUser = $this->drupalCreateUser(['administer blocks']);
+    $this->drupalLogin($this->adminUser);
+    $this->drupalPlaceBlock('localgov_alert_banner_block');
+    $this->drupalLogout($this->adminUser);
+  }
 
   /**
    * Test alert banner block displays.

--- a/tests/src/Functional/PermissionsTest.php
+++ b/tests/src/Functional/PermissionsTest.php
@@ -13,11 +13,6 @@ class PermissionsTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected $profile = 'localgov';
-
-  /**
-   * {@inheritdoc}
-   */
   public static $modules = [
     'localgov_alert_banner',
   ];


### PR DESCRIPTION
Fix #80

Remove tests dependancy on localgov_profile so they can be run with just this
module.
Use place block rather than installing the profile and localgov theme