### PR TITLE
Make banner block type display configurable.

### DIFF
--- a/config/schema/localgov_alert_banner_block.schema.yml
+++ b/config/schema/localgov_alert_banner_block.schema.yml
@@ -1,5 +1,5 @@
 block.settings.localgov_alert_banner_block:
-  type: config_object
+  type: block_settings
   label: 'LocalGov alert banner block settings'
   mapping:
     include_types:

--- a/config/schema/localgov_alert_banner_block.schema.yml
+++ b/config/schema/localgov_alert_banner_block.schema.yml
@@ -1,4 +1,4 @@
-localgov_alert_banner_block.settings:
+block.settings.localgov_alert_banner_block:
   type: config_object
   label: 'LocalGov alert banner block settings'
   mapping:

--- a/config/schema/localgov_alert_banner_block.schema.yml
+++ b/config/schema/localgov_alert_banner_block.schema.yml
@@ -1,0 +1,9 @@
+localgov_alert_banner_block.settings:
+  type: config_object
+  label: 'LocalGov alert banner block settings'
+  mapping:
+    include_types:
+      type: sequence
+        label: 'Displayed alert types'
+        sequence:
+          type: string

--- a/config/schema/localgov_alert_banner_block.schema.yml
+++ b/config/schema/localgov_alert_banner_block.schema.yml
@@ -4,6 +4,6 @@ localgov_alert_banner_block.settings:
   mapping:
     include_types:
       type: sequence
-        label: 'Displayed alert types'
-        sequence:
-          type: string
+      label: 'Displayed alert types'
+      sequence:
+        type: string

--- a/src/Plugin/Block/AlertBannerBlock.php
+++ b/src/Plugin/Block/AlertBannerBlock.php
@@ -161,7 +161,7 @@ class AlertBannerBlock extends BlockBase implements ContainerFactoryPluginInterf
   protected function mapTypesConfigToQuery() : array {
     $include_types = $this->configuration['include_types'];
     return array_filter($include_types, function ($t) {
-      return $t !== 0;
+      return (bool) $t;
     });
   }
 

--- a/src/Plugin/Block/AlertBannerBlock.php
+++ b/src/Plugin/Block/AlertBannerBlock.php
@@ -71,7 +71,7 @@ class AlertBannerBlock extends BlockBase implements ContainerFactoryPluginInterf
    */
   public function defaultConfiguration() {
     return [
-      'types' => [],
+      'include_types' => [],
     ];
   }
 

--- a/src/Plugin/Block/AlertBannerBlock.php
+++ b/src/Plugin/Block/AlertBannerBlock.php
@@ -91,7 +91,7 @@ class AlertBannerBlock extends BlockBase implements ContainerFactoryPluginInterf
       '#options' => $config_options,
       '#title' => $this->t('Display types'),
       '#description' => $this->t('If no types are selected all will be displayed.'),
-      '#default_value' => !empty($config['include_types']) ? $config['include_types'] : '',
+      '#default_value' => !empty($config['include_types']) ? $config['include_types'] : [],
     ];
     return $form;
 

--- a/tests/src/Functional/AlertBannerBlockTest.php
+++ b/tests/src/Functional/AlertBannerBlockTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\localgov_alert_banner\Functional;
 
+use Drupal\block\Entity\Block;
 use Drupal\Tests\BrowserTestBase;
 
 /**
@@ -32,21 +33,44 @@ class AlertBannerBlockTest extends BrowserTestBase {
   protected $adminUser;
 
   /**
-   * {@inheritdoc}
+   * Place the alert block.
+   *
+   * Utility to place the alert banner block so we can assert
+   * against it's output.
+   *
+   * @param array $settings
+   *   The block settings.
+   *
+   * @return \Drupal\block\Entity\Block
+   *   The placed block.
    */
-  protected function setUp() {
-    parent::setUp();
-
+  protected function placeAlterBlock(array $settings = []) {
     $this->adminUser = $this->drupalCreateUser(['administer blocks']);
     $this->drupalLogin($this->adminUser);
-    $this->drupalPlaceBlock('localgov_alert_banner_block');
+    $block = $this->drupalPlaceBlock('localgov_alert_banner_block', $settings);
     $this->drupalLogout($this->adminUser);
+    return $block;
+  }
+
+  /**
+   * Update the settings of an existing block.
+   *
+   * @param \Drupal\block\Entity\Block $block
+   *   The block to update.
+   * @param array $newSettings
+   *   The new settings to merge with the existing settings.
+   */
+  protected function updateBlockSettings(Block $block, array $newSettings) {
+    $settings = $block->get('settings');
+    $block->set('settings', $newSettings + $settings);
+    $block->save();
   }
 
   /**
    * Test alert banner block displays.
    */
   public function testAlertBannerDisplays() {
+    $this->placeAlterBlock();
     // Set up an alert banner.
     $title = $this->randomMachineName(8);
     $alert_message = 'Alert message: ' . $this->randomMachineName(16);
@@ -70,6 +94,7 @@ class AlertBannerBlockTest extends BrowserTestBase {
    * Test non live alert banner does not display.
    */
   public function testNonLiveAlertBannerDoesNotDisplay() {
+    $this->placeAlterBlock();
     // Set up an alert banner.
     $title = $this->randomMachineName(8);
     $alert_message = 'Alert message: ' . $this->randomMachineName(16);
@@ -93,6 +118,7 @@ class AlertBannerBlockTest extends BrowserTestBase {
    * Test display title option.
    */
   public function testAlertDisplayTitle() {
+    $this->placeAlterBlock();
     $title = $this->randomMachineName(8);
     $alert_message = 'Alert message: ' . $this->randomMachineName(16);
     $alert = $this->container->get('entity_type.manager')->getStorage('localgov_alert_banner')
@@ -121,6 +147,7 @@ class AlertBannerBlockTest extends BrowserTestBase {
    * Test remove hide link option.
    */
   public function testAlertRemoveHideLink() {
+    $this->placeAlterBlock();
     $title = $this->randomMachineName(8);
     $alert_message = 'Alert message: ' . $this->randomMachineName(16);
     $alert = $this->container->get('entity_type.manager')->getStorage('localgov_alert_banner')
@@ -144,6 +171,65 @@ class AlertBannerBlockTest extends BrowserTestBase {
     $alert->save();
     $this->drupalGet('<front>');
     $this->assertSession()->responseNotContains('js-alert-banner-close');
+  }
+
+  /**
+   * Test types display option.
+   */
+  public function testAlertBannerTypeDisplay() {
+    $alterType = $this->container->get('entity_type.manager')
+      ->getStorage('localgov_alert_banner_type')
+      ->create(['id' => 'extra_type', 'label' => 'Extra type']);
+    $alterType->save();
+
+    $alert = $this->container->get('entity_type.manager')->getStorage('localgov_alert_banner')
+      ->create([
+        'type' => 'localgov_alert_banner',
+        'title' => 'Alert of type localgov_alert_banner',
+        'display_title' => 1,
+        'status' => TRUE,
+      ]);
+    $alert->save();
+
+    $alert = $this->container->get('entity_type.manager')->getStorage('localgov_alert_banner')
+      ->create([
+        'type' => 'extra_type',
+        'title' => 'Alert of type extra_type',
+        'display_title' => 1,
+        'status' => TRUE,
+      ]);
+    $alert->save();
+
+    // No types selected should result in all types being displayed.
+    $block = $this->placeAlterBlock();
+    $this->drupalGet('<front>');
+    $this->assertSession()->pageTextContains('Alert of type localgov_alert_banner');
+    $this->assertSession()->pageTextContains('Alert of type extra_type');
+
+    $this->updateBlockSettings($block, [
+      'localgov_alert_banner' => 'localgov_alert_banner',
+      'extra_type' => 'extra_type',
+    ]);
+    $this->drupalGet('<front>');
+    $this->assertSession()->pageTextContains('Alert of type localgov_alert_banner');
+    $this->assertSession()->pageTextContains('Alert of type extra_type');
+
+    $this->updateBlockSettings($block, [
+      'localgov_alert_banner' => 'localgov_alert_banner',
+      'extra_type' => '0',
+    ]);
+    $this->drupalGet('<front>');
+    $this->assertSession()->pageTextContains('Alert of type localgov_alert_banner');
+    $this->assertSession()->pageTextNotContains('Alert of type extra_type');
+
+    $this->updateBlockSettings($block, [
+      'localgov_alert_banner' => '0',
+      'extra_type' => 'extra_type',
+    ]);
+    $this->drupalGet('<front>');
+    $this->assertSession()->pageTextNotContains('Alert of type localgov_alert_banner');
+    $this->assertSession()->pageTextContains('Alert of type extra_type');
+
   }
 
 }

--- a/tests/src/Functional/AlertBannerBlockTest.php
+++ b/tests/src/Functional/AlertBannerBlockTest.php
@@ -229,7 +229,7 @@ class AlertBannerBlockTest extends BrowserTestBase {
     $this->updateBlockSettings($block, [
       'include_types' => [
         'localgov_alert_banner' => '0',
-        'extra_type' => '0',
+        'extra_type' => 'extra_type',
       ],
     ]);
     $this->drupalGet('<front>');

--- a/tests/src/Functional/AlertBannerBlockTest.php
+++ b/tests/src/Functional/AlertBannerBlockTest.php
@@ -207,24 +207,30 @@ class AlertBannerBlockTest extends BrowserTestBase {
     $this->assertSession()->pageTextContains('Alert of type extra_type');
 
     $this->updateBlockSettings($block, [
-      'localgov_alert_banner' => 'localgov_alert_banner',
-      'extra_type' => 'extra_type',
+      'include_types' => [
+        'localgov_alert_banner' => 'localgov_alert_banner',
+        'extra_type' => 'extra_type',
+      ],
     ]);
     $this->drupalGet('<front>');
     $this->assertSession()->pageTextContains('Alert of type localgov_alert_banner');
     $this->assertSession()->pageTextContains('Alert of type extra_type');
 
     $this->updateBlockSettings($block, [
-      'localgov_alert_banner' => 'localgov_alert_banner',
-      'extra_type' => '0',
+      'include_types' => [
+        'localgov_alert_banner' => 'localgov_alert_banner',
+        'extra_type' => '0',
+      ],
     ]);
     $this->drupalGet('<front>');
     $this->assertSession()->pageTextContains('Alert of type localgov_alert_banner');
     $this->assertSession()->pageTextNotContains('Alert of type extra_type');
 
     $this->updateBlockSettings($block, [
-      'localgov_alert_banner' => '0',
-      'extra_type' => 'extra_type',
+      'include_types' => [
+        'localgov_alert_banner' => '0',
+        'extra_type' => '0',
+      ],
     ]);
     $this->drupalGet('<front>');
     $this->assertSession()->pageTextNotContains('Alert of type localgov_alert_banner');


### PR DESCRIPTION
* Adds a block form which allows admins to choose the alter banner types they want the block to display
* Use the configuration to filter the queried alter banners before render.