### PR TITLE
Feature/110 Add content local task for alert banners

### DIFF
--- a/config/install/views.view.localgov_admin_manage_alert_banners.yml
+++ b/config/install/views.view.localgov_admin_manage_alert_banners.yml
@@ -849,7 +849,7 @@ display:
       path: admin/content/alert-banner
       menu:
         type: normal
-        title: 'Alert Banners'
+        title: 'Alert banners'
         description: ''
         expanded: false
         parent: system.admin_content

--- a/localgov_alert_banner.install
+++ b/localgov_alert_banner.install
@@ -8,7 +8,7 @@
 use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
- * Update alert banner entity defination to include the token on the entity.
+ * Update alert banner entity definition to include the token on the entity.
  */
 function localgov_alert_banner_update_8801() {
   $field_storage_definition = BaseFieldDefinition::create('string')

--- a/localgov_alert_banner.links.task.yml
+++ b/localgov_alert_banner.links.task.yml
@@ -31,4 +31,4 @@ entity.localgov_alert_banner.delete_form:
 entity.localgov_alert_banner.collection:
   route_name: view.localgov_admin_manage_alert_banners.localgov_alert_banner_admin_list
   base_route:  system.admin_content
-  title: 'Alert Banners'
+  title: 'Alert banners'

--- a/localgov_alert_banner.links.task.yml
+++ b/localgov_alert_banner.links.task.yml
@@ -16,14 +16,19 @@ entity.localgov_alert_banner.version_history:
   title: 'Revisions'
 
 entity.localgov_alert_banner.status_form:
-  route_name:  entity.localgov_alert_banner.status_form
-  base_route:  entity.localgov_alert_banner.canonical
+  route_name: entity.localgov_alert_banner.status_form
+  base_route: entity.localgov_alert_banner.canonical
   title: 'Status'
   weight: 10
   class: '\Drupal\localgov_alert_banner\Plugin\Menu\LocalTask\StatusFormTab'
 
 entity.localgov_alert_banner.delete_form:
-  route_name:  entity.localgov_alert_banner.delete_form
-  base_route:  entity.localgov_alert_banner.canonical
+  route_name: entity.localgov_alert_banner.delete_form
+  base_route: entity.localgov_alert_banner.canonical
   title: Delete
   weight: 10
+
+entity.localgov_alert_banner.collection:
+  route_name: view.localgov_admin_manage_alert_banners.localgov_alert_banner_admin_list
+  base_route:  system.admin_content
+  title: 'Alert Banners'

--- a/localgov_alert_banner.links.task.yml
+++ b/localgov_alert_banner.links.task.yml
@@ -29,6 +29,7 @@ entity.localgov_alert_banner.delete_form:
   weight: 10
 
 entity.localgov_alert_banner.collection:
-  route_name: view.localgov_admin_manage_alert_banners.localgov_alert_banner_admin_list
-  base_route:  system.admin_content
+  route_name: entity.localgov_alert_banner.collection
+  base_route: system.admin_content
   title: 'Alert banners'
+  weight: 50


### PR DESCRIPTION
I have added the 'Alert banners' local task and tested that it appears after routing and links cache is flushed.

I added a second commit which (I believe) corrects some capitalisation and a typo.  I wasn't sure if it's OK to do that in this specific issue.