### PR TITLE
Experimental targeted banners using condition field (for preview purposes)

### DIFF
--- a/localgov_alert_banner.module
+++ b/localgov_alert_banner.module
@@ -108,7 +108,7 @@ function localgov_alert_banner_theme_suggestions_localgov_alert_banner(array $va
 function localgov_alert_banner_localgov_alert_banner_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
 
   // Check if the field is present and has a value.
-  if ($entity->get('field_conditions')->isEmpty()) {
+  if (!$entity->hasField('field_conditions') || $entity->get('field_conditions')->isEmpty()) {
     return TRUE;
   }
 

--- a/localgov_alert_banner.module
+++ b/localgov_alert_banner.module
@@ -7,6 +7,9 @@
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\condition_field\ConditionAccessResolver;
+use Drupal\user\Entity\User;
 
 /**
  * Implements hook_help().
@@ -97,4 +100,62 @@ function localgov_alert_banner_theme_suggestions_localgov_alert_banner(array $va
   $suggestions[] = 'localgov_alert_banner__' . $entity->id();
   $suggestions[] = 'localgov_alert_banner__' . $entity->id() . '__' . $sanitized_view_mode;
   return $suggestions;
+}
+
+/**
+ * Implements hook_localgov_alert_banner_view().
+ */
+function localgov_alert_banner_localgov_alert_banner_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
+
+  // Check if the field is present and has a value.
+  if ($entity->get('field_conditions')->isEmpty()) {
+    return TRUE;
+  }
+
+  // Context handler service.
+  $context_handler = \Drupal::service('context.handler');
+
+  $conditions = [];
+
+  // Get the conditions field value.
+  $conditions_config = $entity->get('field_conditions')->getValue()[0]['conditions'];
+
+  // Condition plugin manager.
+  $manager = \Drupal::service('plugin.manager.condition');
+
+  // Get the current route.
+  $route = \Drupal::routeMatch();
+  $route_name = $route->getRouteName();
+  $route_parameters = $route->getParameters();
+
+  // Bypass condition check if it is the alert banner route or confirmation.
+  $bypass_conditions = ($route_name == 'entity.localgov_alert_banner.canonical' || $route_name == 'entity.localgov_alert_banner.status_form');
+
+  if (!$bypass_conditions) {
+
+    // Loop through each condition.
+    foreach ($conditions_config as $condition_id => $values) {
+
+      // Add current node as context if required and on a node route.
+      $node = $route_parameters->get('node');
+      if ($node && isset($values['context_mapping']['node'])) {
+        $values['context']['node'] = $node;
+      }
+
+      // Add user as current context if required.
+      if (isset($values['context_mapping']['user'])) {
+        $values['context']['user'] = User::load(\Drupal::currentUser()->id());
+      }
+
+      // Construct condition.
+      /** @var \Drupal\Core\Condition\ConditionInterface $condition */
+      $conditions[] = $manager->createInstance($condition_id, $values);
+    }
+
+    // Visible if any condition is met.
+    $isVisible = ConditionAccessResolver::checkAccess($conditions, 'or');
+    if (!$isVisible) {
+      $build = [];
+    }
+  }
 }


### PR DESCRIPTION
Add condition field support so that some banners can be limited to certain pages based on conditions plugins.

Ref #120 

Requires condition_field
  https://drupal.org/project/condition_field

To test, edit an alert banner type and add a condition field named `field_conditions`
Now you should be able to set up alert banner entities, and set visibility conditions on them.

This is a preview of potential condition support, so we need to decide if we will rely on a dependancy, or bake in conditions plugin support into the module.