### PR TITLE
Render all content fields on the alert banner

### DIFF
--- a/templates/localgov-alert-banner.html.twig
+++ b/templates/localgov-alert-banner.html.twig
@@ -46,7 +46,7 @@
         {% endif %}
         
         <div class="localgov-alert-banner__body">
-          {{ content|without('title', 'link' }}
+          {{ content|without('title', 'link') }}
         </div>
 
         {% if has_link %}

--- a/templates/localgov-alert-banner.html.twig
+++ b/templates/localgov-alert-banner.html.twig
@@ -45,11 +45,9 @@
           </h2>
         {% endif %}
         
-        {% if content.short_description.0['#text'] %}
-          <div class="localgov-alert-banner__body">
-            {{ content.short_description }}
-          </div>
-        {% endif %}
+        <div class="localgov-alert-banner__body">
+          {{ content|without('title', 'link' }}
+        </div>
 
         {% if has_link %}
           <div class="localgov-alert-banner--content-link">{{ content.link }}</div>


### PR DESCRIPTION
Fix #143.
Use twig without filter to not print out the title or the link field, instead of just the description.