### PR TITLE
Fix display the banner link when no title

### DIFF
--- a/templates/localgov-alert-banner.html.twig
+++ b/templates/localgov-alert-banner.html.twig
@@ -21,7 +21,7 @@
 
 {{ attach_library('localgov_alert_banner/alert_banner') }}
 
-{% set has_link = content.link.0 is not empty %}
+{% set has_link = content.link|render is not empty %}
 {% set type_of_alert =  type_of_alert|split('--')[1]|clean_class %}
 {% set classes = [
     'js-localgov-alert-banner',


### PR DESCRIPTION
Fix #147 

This will show the link if it is present but does not have a title.