### PR TITLE
Move the cacheContexts and cacheTags to the alert banner entity

### DIFF
--- a/localgov_alert_banner.module
+++ b/localgov_alert_banner.module
@@ -5,7 +5,6 @@
  * Contains localgov_alert_banner.module.
  */
 
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 
 /**
@@ -21,28 +20,6 @@ function localgov_alert_banner_help($route_name, RouteMatchInterface $route_matc
       return $output;
 
     default:
-  }
-}
-
-/**
- * Implements hook_entity_build_defaults_alter().
- */
-function localgov_alert_banner_entity_build_defaults_alter(array &$build, EntityInterface $entity, $view_mode) {
-
-  // Add cache contexts for the alert banner.
-  if ($entity->bundle() == 'localgov_alert_banner') {
-
-    // Set a cache context based on the hide alert banner cookie token.
-    $build['#cache']['contexts'][] = 'cookies:hide-alert-banner-token';
-    $build['#cache']['contexts'][] = 'user.roles:anonymous';
-    $build['#cache']['contexts'][] = 'session';
-
-    // Set a cache context based on if on the front page.
-    $build['#cache']['contexts'][] = 'url.path.is_front';
-
-    // Get token and use as a cache tag.
-    $token = $entity->getToken();
-    $build['#cache']['tags'][] = 'localgov.alert.banner.token:' . $token;
   }
 }
 

--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -392,9 +392,12 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
    */
   public function getCacheContexts() {
 
+    $contexts = [];
+    $contexts = Cache::mergeContexts($contexts, ['url.path.is_front']);
+
     // Add cache contexts depending on the enabled visibility condition plugins.
     if ($this->hasField('visibility') && !$this->get('visibility')->isEmpty()) {
-      $contexts = [];
+
       $conditions_config = $this->get('visibility')->getValue()[0]['conditions'];
 
       foreach ($conditions_config as $condition_id => $values) {
@@ -406,7 +409,21 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
       $this->addCacheContexts($contexts);
     }
 
-    return parent::getCacheContexts();
+    return Cache::mergeContexts(parent::getCacheContexts(), $contexts);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheTags() {
+
+    $cache_tags = [];
+
+    // Get token and use as a cache tag.
+    $token = $this->getToken();
+    $cache_tags = Cache::mergeTags($cache_tags, ['localgov.alert.banner.token:' . $token]);
+
+    return Cache::mergeTags(parent::getCacheTags(), $cache_tags);
   }
 
 }

--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -392,6 +392,7 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
    */
   public function getCacheContexts() {
 
+    // Add front page context for front page classes.
     $contexts = ['url.path.is_front'];
 
     // Add cache contexts depending on the enabled visibility condition plugins.
@@ -406,11 +407,8 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
       }
     }
 
-    // Add to the main cache contexts.
-    $this->addCacheContexts($contexts);
-
     // Return cache contexts.
-    return parent::getCacheContexts();
+    return Cache::mergeContexts(parent::getCacheContexts(), $contexts);
   }
 
   /**
@@ -420,7 +418,7 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
 
     // Get token and use as a cache tag.
     $token = $this->getToken();
-    $cache_tags = ['localgov.alert.banner.token:' . $token];;
+    $cache_tags = ['localgov.alert.banner.token:' . $token];
 
     return Cache::mergeTags(parent::getCacheTags(), $cache_tags);
   }

--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -392,8 +392,7 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
    */
   public function getCacheContexts() {
 
-    $contexts = [];
-    $contexts = Cache::mergeContexts($contexts, ['url.path.is_front']);
+    $contexts = ['url.path.is_front'];
 
     // Add cache contexts depending on the enabled visibility condition plugins.
     if ($this->hasField('visibility') && !$this->get('visibility')->isEmpty()) {
@@ -405,11 +404,13 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
         $condition = $this->pluginManagerCondition->createInstance($condition_id, $values);
         $contexts = Cache::mergeContexts($contexts, $condition->getCacheContexts());
       }
-
-      $this->addCacheContexts($contexts);
     }
 
-    return Cache::mergeContexts(parent::getCacheContexts(), $contexts);
+    // Add to the main cache contexts.
+    $this->addCacheContexts($contexts);
+
+    // Return cache contexts.
+    return parent::getCacheContexts();
   }
 
   /**
@@ -417,11 +418,9 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
    */
   public function getCacheTags() {
 
-    $cache_tags = [];
-
     // Get token and use as a cache tag.
     $token = $this->getToken();
-    $cache_tags = Cache::mergeTags($cache_tags, ['localgov.alert.banner.token:' . $token]);
+    $cache_tags = ['localgov.alert.banner.token:' . $token];;
 
     return Cache::mergeTags(parent::getCacheTags(), $cache_tags);
   }


### PR DESCRIPTION
Fix #150

- Remove the session and user role contexts
- Move cache contexts to alert banner entity
- Move cache tags to alert banner entity
