### PR TITLE
Fix adding cache contexts only when it has an effect on visibility

### DIFF
--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -398,6 +398,18 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
       $conditions_config = $this->get('visibility')->getValue()[0]['conditions'];
 
       foreach ($conditions_config as $condition_id => $values) {
+
+        // Skip adding contexts for banners that arn't visible.
+        // @see #154
+        // Show banner on restricted pages, skip when hidden.
+        if (!$this->isVisible() && $values['negate'] == 0) {
+          continue;
+        }
+        // Hide banner on restricted pages, skip when visible.
+        if ($this->isVisible() && $values['negate'] == 1) {
+          continue;
+        }
+
         /** @var \Drupal\Core\Condition\ConditionInterface $condition */
         $condition = $this->pluginManagerCondition->createInstance($condition_id, $values);
         $contexts = Cache::mergeContexts($contexts, $condition->getCacheContexts());

--- a/src/Plugin/Block/AlertBannerBlock.php
+++ b/src/Plugin/Block/AlertBannerBlock.php
@@ -129,8 +129,13 @@ class AlertBannerBlock extends BlockBase implements ContainerFactoryPluginInterf
     // Render the alert banner.
     $build = [];
     foreach ($this->currentAlertBanners as $alert_banner) {
-      $build[] = $this->entityTypeManager->getViewBuilder('localgov_alert_banner')
-        ->view($alert_banner);
+
+      // Only add to the build if it is visible.
+      // @see #154.
+      if ($alert_banner->isVisible()) {
+        $build[] = $this->entityTypeManager->getViewBuilder('localgov_alert_banner')
+          ->view($alert_banner);
+      }
     }
     return $build;
   }
@@ -159,12 +164,11 @@ class AlertBannerBlock extends BlockBase implements ContainerFactoryPluginInterf
     }
     $published_alert_banners = $published_alert_banner_query->execute();
 
-    // Load alert banners and check they're visible.
+    // Load alert banners and add all.
+    // Visibility check happens in build, so we get cache contexts on all.
     foreach ($published_alert_banners as $alert_banner_id) {
       $alert_banner = $this->entityTypeManager->getStorage('localgov_alert_banner')->load($alert_banner_id);
-      if ($alert_banner->isVisible()) {
-        $alert_banners[] = $alert_banner;
-      }
+      $alert_banners[] = $alert_banner;
     }
 
     return $alert_banners;


### PR DESCRIPTION
Fix #154

eg. When a banner is set to show on specific pages, only add the cache context for url.path
when the current path is one of those pages.
When a banner is set to be hidden on specific pages, only add the cache context for url.path
when the current path is one of those pages, and skip on the rest.
