### PR TITLE
swap modifier to element to follow BEM

### DIFF
--- a/templates/localgov-alert-banner.html.twig
+++ b/templates/localgov-alert-banner.html.twig
@@ -50,7 +50,7 @@
         </div>
 
         {% if has_link %}
-          <div class="localgov-alert-banner--content-link">{{ content.link }}</div>
+          <div class="localgov-alert-banner__content-link">{{ content.link }}</div>
         {% endif %}
       </div> {# End Content #}
 


### PR DESCRIPTION
A tiny PR to change

`<div class="localgov-alert-banner--content-link">{{ content.link }}</div>`

to

`<div class="localgov-alert-banner__content-link">{{ content.link }}</div>`

So we follow BEM properly. This class is not used in the module's CSS so should not break anything.