### PR TITLE
Cache clear can now rely on cache tag invalidation

### DIFF
--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -162,8 +162,10 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
   public function postSave(EntityStorageInterface $storage, $update = TRUE) {
     parent::postSave($storage, $update);
 
-    // Better to use cache tags instead of doing a full flush?
-    drupal_flush_all_caches();
+    // Needed by the entity.localgov_alert_banner.status_form route to function
+    // correctly during *test runs*.  Not the ideal solution, but less
+    // destructive than drupal_flush_all_caches().
+    \Drupal::service('router.builder')->setRebuildNeeded();
   }
 
   /**

--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -159,6 +159,16 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
   /**
    * {@inheritdoc}
    */
+  public function postSave(EntityStorageInterface $storage, $update = TRUE) {
+    parent::postSave($storage, $update);
+
+    // Better to use cache tags instead of doing a full flush?
+    drupal_flush_all_caches();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getTitle() {
     return $this->get('title')->value;
   }

--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -159,16 +159,6 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
   /**
    * {@inheritdoc}
    */
-  public function postSave(EntityStorageInterface $storage, $update = TRUE) {
-    parent::postSave($storage, $update);
-
-    // Better to use cache tags instead of doing a full flush?
-    drupal_flush_all_caches();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function getTitle() {
     return $this->get('title')->value;
   }


### PR DESCRIPTION
This comment in the dropped code says it best:
> Better to use cache tags instead of doing a full flush?"

#resolves #126