### PR TITLE
1.1.2 Release

### DIFF
--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -162,8 +162,10 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
   public function postSave(EntityStorageInterface $storage, $update = TRUE) {
     parent::postSave($storage, $update);
 
-    // Better to use cache tags instead of doing a full flush?
-    drupal_flush_all_caches();
+    // Needed by the entity.localgov_alert_banner.status_form route to function
+    // correctly during *test runs*.  Not the ideal solution, but less
+    // destructive than drupal_flush_all_caches().
+    \Drupal::service('router.builder')->setRebuildNeeded();
   }
 
   /**

--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -398,6 +398,18 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
       $conditions_config = $this->get('visibility')->getValue()[0]['conditions'];
 
       foreach ($conditions_config as $condition_id => $values) {
+
+        // Skip adding contexts for banners that arn't visible.
+        // @see #154
+        // Show banner on restricted pages, skip when hidden.
+        if (!$this->isVisible() && $values['negate'] == 0) {
+          continue;
+        }
+        // Hide banner on restricted pages, skip when visible.
+        if ($this->isVisible() && $values['negate'] == 1) {
+          continue;
+        }
+
         /** @var \Drupal\Core\Condition\ConditionInterface $condition */
         $condition = $this->pluginManagerCondition->createInstance($condition_id, $values);
         $contexts = Cache::mergeContexts($contexts, $condition->getCacheContexts());

--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -159,6 +159,16 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
   /**
    * {@inheritdoc}
    */
+  public function postSave(EntityStorageInterface $storage, $update = TRUE) {
+    parent::postSave($storage, $update);
+
+    // Better to use cache tags instead of doing a full flush?
+    drupal_flush_all_caches();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getTitle() {
     return $this->get('title')->value;
   }

--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -159,16 +159,6 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
   /**
    * {@inheritdoc}
    */
-  public function postSave(EntityStorageInterface $storage, $update = TRUE) {
-    parent::postSave($storage, $update);
-
-    // Better to use cache tags instead of doing a full flush?
-    drupal_flush_all_caches();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function getTitle() {
     return $this->get('title')->value;
   }

--- a/src/Plugin/Block/AlertBannerBlock.php
+++ b/src/Plugin/Block/AlertBannerBlock.php
@@ -129,8 +129,13 @@ class AlertBannerBlock extends BlockBase implements ContainerFactoryPluginInterf
     // Render the alert banner.
     $build = [];
     foreach ($this->currentAlertBanners as $alert_banner) {
-      $build[] = $this->entityTypeManager->getViewBuilder('localgov_alert_banner')
-        ->view($alert_banner);
+
+      // Only add to the build if it is visible.
+      // @see #154.
+      if ($alert_banner->isVisible()) {
+        $build[] = $this->entityTypeManager->getViewBuilder('localgov_alert_banner')
+          ->view($alert_banner);
+      }
     }
     return $build;
   }
@@ -159,12 +164,11 @@ class AlertBannerBlock extends BlockBase implements ContainerFactoryPluginInterf
     }
     $published_alert_banners = $published_alert_banner_query->execute();
 
-    // Load alert banners and check they're visible.
+    // Load alert banners and add all.
+    // Visibility check happens in build, so we get cache contexts on all.
     foreach ($published_alert_banners as $alert_banner_id) {
       $alert_banner = $this->entityTypeManager->getStorage('localgov_alert_banner')->load($alert_banner_id);
-      if ($alert_banner->isVisible()) {
-        $alert_banners[] = $alert_banner;
-      }
+      $alert_banners[] = $alert_banner;
     }
 
     return $alert_banners;

--- a/templates/localgov-alert-banner.html.twig
+++ b/templates/localgov-alert-banner.html.twig
@@ -50,7 +50,7 @@
         </div>
 
         {% if has_link %}
-          <div class="localgov-alert-banner--content-link">{{ content.link }}</div>
+          <div class="localgov-alert-banner__content-link">{{ content.link }}</div>
         {% endif %}
       </div> {# End Content #}
 

--- a/templates/localgov-alert-banner.html.twig
+++ b/templates/localgov-alert-banner.html.twig
@@ -21,7 +21,7 @@
 
 {{ attach_library('localgov_alert_banner/alert_banner') }}
 
-{% set has_link = content.link.0 is not empty %}
+{% set has_link = content.link|render is not empty %}
 {% set type_of_alert =  type_of_alert|split('--')[1]|clean_class %}
 {% set classes = [
     'js-localgov-alert-banner',


### PR DESCRIPTION
Should be last bugfix release before schduled alert banners in 1.2.

Commits on Jul 02, 2021
@andybroomfield
Fix adding cache contexts only when it has an effect on visibility …
ab0a712
Commits on Jul 05, 2021
@markconroy
swap modifier to element to follow BEM
77f3a83
Commits on Jul 07, 2021
@andybroomfield
Fix display the banner link when no title …
5c46105
Commits on Jul 08, 2021
@Adnan-cds
Cache clear can now rely on cache tag invalidation. …
430d0e6
@markconroy
Merge pull request #157 from localgovdrupal/hotfix/1.x-bem-coding-sta… …
1d7638c
@markconroy
Merge pull request #148 from localgovdrupal/fix/147-link-no-title …
a0f2c7d
Commits on Jul 16, 2021
@Adnan-cds
Revert "Cache clear can now rely on cache tag invalidation." …
d5a57ca
@Adnan-cds
Cache clear improvement. …
ec37303
@andybroomfield
Merge pull request #155 from localgovdrupal/fix/154-cache-context-con… …
c1ce09c
Commits on Jul 26, 2021
@andybroomfield
Merge pull request #158 from localgovdrupal/feature/no-flush-all-cache …