### PR TITLE
Test fix test - Update blocks to use the new LocalGov Base theme

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,10 +44,16 @@ jobs:
       - name: Set composer branch reference for main version branches
         if: endsWith(github.ref, '.x')
         run: echo "COMPOSER_REF=${GIT_BRANCH}-dev" >> $GITHUB_ENV
-  
+
       - name: Set composer branch reference for main version branches
         if: endsWith(github.ref, '.x') == false
         run: echo "COMPOSER_REF=dev-${GIT_BRANCH}" >> $GITHUB_ENV
+
+      - name: Get the latest tagged release for branch version
+        run: |
+          LATEST_RELEASE=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/localgovdrupal/localgov_alert_banner/git/matching-refs/tags/${GIT_BASE%'.x'} | grep -Po '(?<=refs/tags/)[^"]+' | tail -1)
+          if [ -z $LATEST_RELEASE ]; then LATEST_RELEASE=1; fi
+          echo "LATEST_RELEASE=${LATEST_RELEASE}" >> $GITHUB_ENV
 
       - name: Cached workspace
         uses: actions/cache@v2
@@ -69,22 +75,17 @@ jobs:
       - name: Create LocalGov Drupal project
         run: |
           composer create-project --stability dev --no-install localgovdrupal/localgov-project ./html "${{ matrix.localgov-version }}"
-<<<<<<< HEAD
-          composer require --no-install drupal/core-recommended:${{ matrix.drupal-version }} drupal/core-composer-scaffold:${{ matrix.drupal-version }} drupal/core-project-message:${{ matrix.drupal-version }} drupal/core-dev:${{ matrix.drupal-version }}
-          composer install
-=======
           composer --working-dir=./html require --no-install localgovdrupal/localgov:${{ matrix.localgov-version }}-dev
           composer --working-dir=./html require --no-install drupal/core-recommended:${{ matrix.drupal-version }} drupal/core-composer-scaffold:${{ matrix.drupal-version }} drupal/core-project-message:${{ matrix.drupal-version }} drupal/core-dev:${{ matrix.drupal-version }}
           composer --working-dir=./html install
->>>>>>> 4a4091c (Fixing GitHub actions config)
 
       - name: Setup package source and authentication for the test target
         run: |
-          composer --working-dir=html config repositories.1 vcs git@github.com:${GIT_REPO}.git
+          composer --working-dir=./html config repositories.1 vcs git@github.com:${GIT_REPO}.git
           composer global config github-oauth.github.com ${{ github.token }}
 
       - name: Obtain the test target from the repo that triggered this workflow
-        run: composer --working-dir=html require --with-all-dependencies localgovdrupal/${{ github.event.repository.name }}:"${COMPOSER_REF} as ${GIT_BASE%'.x'}"
+        run: composer --working-dir=./html require --with-all-dependencies localgovdrupal/${{ github.event.repository.name }}:"${COMPOSER_REF} as ${LATEST_RELEASE}"
 
   phpcs:
     name: Coding standards checks
@@ -196,11 +197,9 @@ jobs:
       - name: Run PHPUnit tests
         env:
           LOCALGOV_VERSION: ${{ matrix.localgov-version }}
-          RANDOMIZE_TESTS: ""
         run: |
-          [ "${LOCALGOV_VERSION}" != "1.x" ] && RANDOMIZE_TESTS="--order-by=random"
           mkdir -p ./html/web/sites/simpletest && chmod 777 ./html/web/sites/simpletest
           sed -i "s#http://localgov.lndo.site#http://drupal#; s#mysql://database:database@database/database#sqlite://localhost//dev/shm/test.sqlite#" ./html/phpunit.xml.dist
           docker exec -t drupal bash -c 'chown docker:docker -R /var/www/html'
           # docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/phpunit --testdox"
-          docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/paratest --processes=4 ${RANDOMIZE_TESTS}"
+          docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/paratest --processes=4"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,8 +69,14 @@ jobs:
       - name: Create LocalGov Drupal project
         run: |
           composer create-project --stability dev --no-install localgovdrupal/localgov-project ./html "${{ matrix.localgov-version }}"
+<<<<<<< HEAD
           composer require --no-install drupal/core-recommended:${{ matrix.drupal-version }} drupal/core-composer-scaffold:${{ matrix.drupal-version }} drupal/core-project-message:${{ matrix.drupal-version }} drupal/core-dev:${{ matrix.drupal-version }}
           composer install
+=======
+          composer --working-dir=./html require --no-install localgovdrupal/localgov:${{ matrix.localgov-version }}-dev
+          composer --working-dir=./html require --no-install drupal/core-recommended:${{ matrix.drupal-version }} drupal/core-composer-scaffold:${{ matrix.drupal-version }} drupal/core-project-message:${{ matrix.drupal-version }} drupal/core-dev:${{ matrix.drupal-version }}
+          composer --working-dir=./html install
+>>>>>>> 4a4091c (Fixing GitHub actions config)
 
       - name: Setup package source and authentication for the test target
         run: |

--- a/config/optional/block.block.localgov_alert_banner.yml
+++ b/config/optional/block.block.localgov_alert_banner.yml
@@ -4,9 +4,9 @@ dependencies:
   module:
     - localgov_alert_banner
   theme:
-    - localgov_theme
+    - localgov_base
 id: localgov_alert_banner
-theme: localgov_theme
+theme: localgov_base
 region: banner
 weight: 0
 provider: null

--- a/tests/src/FunctionalJavascript/AlertBannerHideTest.php
+++ b/tests/src/FunctionalJavascript/AlertBannerHideTest.php
@@ -12,7 +12,7 @@ class AlertBannerHideTest extends WebDriverTestBase {
   /**
    * {@inheritdoc}
    */
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'classy';
 
   /**
    * {@inheritdoc}

--- a/tests/src/FunctionalJavascript/AlertBannerHideTest.php
+++ b/tests/src/FunctionalJavascript/AlertBannerHideTest.php
@@ -12,7 +12,7 @@ class AlertBannerHideTest extends WebDriverTestBase {
   /**
    * {@inheritdoc}
    */
-  protected $defaultTheme = 'localgov_theme';
+  protected $defaultTheme = 'localgov_base';
 
   /**
    * {@inheritdoc}
@@ -30,6 +30,8 @@ class AlertBannerHideTest extends WebDriverTestBase {
    * Test alert banner hide link.
    */
   public function testAlertBannerHide() {
+    $this->drupalPlaceBlock('localgov_alert_banner');
+
     // Set up an alert banner.
     $title = $this->randomMachineName(8);
     $alert_message = 'Alert message: ' . $this->randomMachineName(16);

--- a/tests/src/FunctionalJavascript/AlertBannerHideTest.php
+++ b/tests/src/FunctionalJavascript/AlertBannerHideTest.php
@@ -12,7 +12,7 @@ class AlertBannerHideTest extends WebDriverTestBase {
   /**
    * {@inheritdoc}
    */
-  protected $defaultTheme = 'localgov_base';
+  protected $defaultTheme = 'stable';
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
Test with cherry picks to resolve test fail

- Cache clear can now rely on cache tag invalidation.
- Revert "Cache clear can now rely on cache tag invalidation."
- Cache clear improvement.
- Update all block config to use localgov_base theme (localgovdrupal/localgov#288)
- Use localgov_base theme in tests
- Fixing GitHub actions config
