### PR TITLE
Alternative Schdule Alert Banners (Do it in the module rather than third party)

### DIFF
--- a/localgov_alert_banner.install
+++ b/localgov_alert_banner.install
@@ -81,7 +81,6 @@ function localgov_alert_banner_update_8902() {
     ->setDisplayConfigurable('form', TRUE)
     ->setDisplayConfigurable('view', FALSE);
 
-
   \Drupal::entityDefinitionUpdateManager()
     ->installFieldStorageDefinition('date_put_live', 'localgov_alert_banner', 'localgov_alert_banner', $field_storage_definition_put_live);
 
@@ -94,7 +93,6 @@ function localgov_alert_banner_update_8902() {
     ])
     ->setDisplayConfigurable('form', TRUE)
     ->setDisplayConfigurable('view', FALSE);
-
 
   \Drupal::entityDefinitionUpdateManager()
     ->installFieldStorageDefinition('date_remove', 'localgov_alert_banner', 'localgov_alert_banner', $field_storage_definition_remove);

--- a/localgov_alert_banner.install
+++ b/localgov_alert_banner.install
@@ -66,3 +66,36 @@ function localgov_alert_banner_update_8901() {
     }
   }
 }
+
+/**
+ * Update alert banner entity definition to include scheduled date.
+ */
+function localgov_alert_banner_update_8902() {
+  $field_storage_definition_put_live = BaseFieldDefinition::create('datetime')
+    ->setLabel(t('Put live on date'))
+    ->setDescription(t('If set, the banner will be put live on this date and time.'))
+    ->setRevisionable(TRUE)
+    ->setDisplayOptions('form', [
+      'weight' => -4,
+    ])
+    ->setDisplayConfigurable('form', TRUE)
+    ->setDisplayConfigurable('view', FALSE);
+
+
+  \Drupal::entityDefinitionUpdateManager()
+    ->installFieldStorageDefinition('date_put_live', 'localgov_alert_banner', 'localgov_alert_banner', $field_storage_definition_put_live);
+
+  $field_storage_definition_remove = BaseFieldDefinition::create('datetime')
+    ->setLabel(t('Remove on date'))
+    ->setDescription(t('If set, the banner will be removed on this date and time.'))
+    ->setRevisionable(TRUE)
+    ->setDisplayOptions('form', [
+      'weight' => -4,
+    ])
+    ->setDisplayConfigurable('form', TRUE)
+    ->setDisplayConfigurable('view', FALSE);
+
+
+  \Drupal::entityDefinitionUpdateManager()
+    ->installFieldStorageDefinition('date_remove', 'localgov_alert_banner', 'localgov_alert_banner', $field_storage_definition_remove);
+}

--- a/localgov_alert_banner.module
+++ b/localgov_alert_banner.module
@@ -6,6 +6,8 @@
  */
 
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\Core\Datetime\DrupalDateTime;
 
 /**
  * Implements hook_help().
@@ -74,4 +76,39 @@ function localgov_alert_banner_theme_suggestions_localgov_alert_banner(array $va
   $suggestions[] = 'localgov_alert_banner__' . $entity->id();
   $suggestions[] = 'localgov_alert_banner__' . $entity->id() . '__' . $sanitized_view_mode;
   return $suggestions;
+}
+
+/**
+ * Implements hook_cron().
+ */
+function localgov_alert_banner_cron() {
+
+  // Get current time.
+  $now = new DrupalDateTime('now');
+  $now->setTimezone(new \DateTimeZone(DateTimeItemInterface::STORAGE_TIMEZONE));
+  $now_formatted = $now->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT);
+
+  // Get alert banners that need to be put live.
+  $alert_banner_storage = \Drupal::entityTypeManager()->getStorage('localgov_alert_banner');
+  $alert_banner_ids = $alert_banner_storage->getQuery()->condition('status', '0')
+                                                       ->condition('date_put_live', $now_formatted, '<=')
+                                                       ->condition('date_remove', $now_formatted, '>')
+                                                       ->execute();
+
+  foreach ($alert_banner_ids as $id) {
+    $alert_banner_storage->load($id)
+                         ->set('status', '1')
+                         ->save();
+  }
+
+  // Get alert banners that need to be removed.
+  $alert_banner_storage = \Drupal::entityTypeManager()->getStorage('localgov_alert_banner');
+  $alert_banner_ids = $alert_banner_storage->getQuery()->condition('status', '1')
+                                                       ->condition('date_remove', $now_formatted, '<=')
+                                                       ->execute();
+  foreach ($alert_banner_ids as $id) {
+    $alert_banner_storage->load($id)
+                         ->set('status', '0')
+                         ->save();
+  }
 }

--- a/localgov_alert_banner.module
+++ b/localgov_alert_banner.module
@@ -91,24 +91,24 @@ function localgov_alert_banner_cron() {
   // Get alert banners that need to be put live.
   $alert_banner_storage = \Drupal::entityTypeManager()->getStorage('localgov_alert_banner');
   $alert_banner_ids = $alert_banner_storage->getQuery()->condition('status', '0')
-                                                       ->condition('date_put_live', $now_formatted, '<=')
-                                                       ->condition('date_remove', $now_formatted, '>')
-                                                       ->execute();
+    ->condition('date_put_live', $now_formatted, '<=')
+    ->condition('date_remove', $now_formatted, '>')
+    ->execute();
 
   foreach ($alert_banner_ids as $id) {
     $alert_banner_storage->load($id)
-                         ->set('status', '1')
-                         ->save();
+      ->set('status', '1')
+      ->save();
   }
 
   // Get alert banners that need to be removed.
   $alert_banner_storage = \Drupal::entityTypeManager()->getStorage('localgov_alert_banner');
   $alert_banner_ids = $alert_banner_storage->getQuery()->condition('status', '1')
-                                                       ->condition('date_remove', $now_formatted, '<=')
-                                                       ->execute();
+    ->condition('date_remove', $now_formatted, '<=')
+    ->execute();
   foreach ($alert_banner_ids as $id) {
     $alert_banner_storage->load($id)
-                         ->set('status', '0')
-                         ->save();
+      ->set('status', '0')
+      ->save();
   }
 }

--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -365,6 +365,28 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
         'weight' => -3,
       ]);
 
+    // Scheduled options.
+    $fields['date_put_live'] = BaseFieldDefinition::create('datetime')
+      ->setLabel(t('Put live on date'))
+      ->setDescription(t('If set, the banner will be put live on this date and time.'))
+      ->setRevisionable(TRUE)
+      ->setDisplayOptions('form', [
+        'weight' => -4,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', FALSE);
+
+    // Scheduled options.
+    $fields['date_remove'] = BaseFieldDefinition::create('datetime')
+      ->setLabel(t('Remove on date'))
+      ->setDescription(t('If set, the banner will be removed on this date and time.'))
+      ->setRevisionable(TRUE)
+      ->setDisplayOptions('form', [
+        'weight' => -4,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', FALSE);
+
     $fields['created'] = BaseFieldDefinition::create('created')
       ->setLabel(t('Created'))
       ->setDescription(t('The time that the entity was created.'));


### PR DESCRIPTION
Initial draft version, adds to new datetime fields to the alert banner entity for put live / remove.
Then handles the set live / remove on the modules own cron job.

I think this may be a more optimal solution than third party modules to handle scheduling. This keeps the module without having to add Workflow and the complications of handling the scheduler transitions screen. The dates for the banner publishing are handled as the entity is being created. This will also allow sites that arn't using localgov_workflows yet to still using scheduled alert banners. 

I also think this should keep the entity and the banners module easier to maintain.

/cc @stephen-cox @Adnan-cds @danchamp 

