### PR TITLE
Send string in both instances of revision link for table. Fixes #169

### DIFF
--- a/src/Controller/AlertBannerEntityController.php
+++ b/src/Controller/AlertBannerEntityController.php
@@ -130,7 +130,7 @@ class AlertBannerEntityController extends ControllerBase implements ContainerInj
           $link = Link::fromTextAndUrl($date, new Url('entity.localgov_alert_banner.revision', [
             'localgov_alert_banner' => $localgov_alert_banner->id(),
             'localgov_alert_banner_revision' => $vid,
-          ]));
+          ]))->toString();
         }
         else {
           $link = $localgov_alert_banner->toLink($date)->toString();


### PR DESCRIPTION
Date link sent to table was either a string for the current revision, or Link object for other revisions. Changed to string.