### PR TITLE
Add alert banner title to the hide button aria-label attribute

### DIFF
--- a/templates/localgov-alert-banner.html.twig
+++ b/templates/localgov-alert-banner.html.twig
@@ -44,7 +44,7 @@
             {{ content.title }}
           </h2>
         {% endif %}
-        
+
         <div class="localgov-alert-banner__body">
           {{ content|without('title', 'link') }}
         </div>
@@ -57,7 +57,7 @@
       {% if not remove_hide_link %}
         <div class="localgov-alert-banner__actions">
           <div class="localgov-alert-banner__dismiss">
-            <button class="localgov-alert-banner__close js-localgov-alert-banner__close" aria-label="{{ 'Hide alert'|t }}">{{ 'Hide'|t }}</button>
+            <button class="localgov-alert-banner__close js-localgov-alert-banner__close" aria-label="{{ 'Hide alert'|t ~ ': ' ~ content.title|render|striptags|trim }}">{{ 'Hide'|t }}</button>
           </div>
         </div>
       {% endif %}


### PR DESCRIPTION
Closes #177 

Appends alert banner title to the 'Hide alert' button aria-label.

There may be a better way of accessing the plain text of the title?