### PR TITLE
Remove 1.x (drupal 8) tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - localgov-version: "1.x"
-            drupal-version: "~8.9"
-            php-version: "7.4"
           - localgov-version: "2.x"
             drupal-version: "~9.1"
             php-version: "7.4"


### PR DESCRIPTION
Fix #183 

Drupal 8 / localgov 1 not no longer (fully) supported, so no longer run full tests.