### PR TITLE
"Remove hide link" checkbox for full page banner

### DIFF
--- a/modules/localgov_alert_banner_full_page/config/install/core.entity_form_display.localgov_alert_banner.localgov_full_page.default.yml
+++ b/modules/localgov_alert_banner_full_page/config/install/core.entity_form_display.localgov_alert_banner.localgov_full_page.default.yml
@@ -46,13 +46,6 @@ content:
       media_types: {  }
     third_party_settings: {  }
     region: content
-  remove_hide_link:
-    type: boolean_checkbox
-    weight: 3
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
   title:
     type: string_textfield
     weight: 1
@@ -77,4 +70,5 @@ content:
       match_limit: 10
     region: content
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  remove_hide_link: true

--- a/modules/localgov_alert_banner_full_page/localgov_alert_banner_full_page.install
+++ b/modules/localgov_alert_banner_full_page/localgov_alert_banner_full_page.install
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file
+ * Module updates.
+ */
+
+declare(strict_types = 1);
+
+/**
+ * Implements hook_update_N().
+ *
+ * Hides the "Remove hide link" checkbox from Full page alert edit pages.
+ */
+function localgov_alert_banner_full_page_update_9001() {
+
+  $form_display = Drupal::service('entity_type.manager')
+    ->getStorage('entity_form_display')
+    ->load('localgov_alert_banner.localgov_full_page.default');
+  if (!$form_display) {
+    return t('Cannot find form display for Full page alert.');
+  }
+
+  $remove_hide_link = $form_display->getComponent('remove_hide_link');
+  if ($remove_hide_link) {
+    $form_display->removeComponent('remove_hide_link')->save();
+  }
+  else {
+    return t('Cannot find settings for the "Remove hide link" checkbox.');
+  }
+}


### PR DESCRIPTION
Resolves #189

Updated config file and accompanying programmatic update to hide the "Remove hide link" checkbox from the Full page alert banner's edit form.

The "Remove hide link" checkbox is irrelevant for Full page alert banners as we don't want to remove the "Hide" link from full page banners.  This is because a full page banner without a hide link prevents people from reaching the actual site content!