### PR TITLE
Default the unpublish other alert banners to off

### DIFF
--- a/src/Form/AlertBannerEntityStatusForm.php
+++ b/src/Form/AlertBannerEntityStatusForm.php
@@ -68,7 +68,7 @@ class AlertBannerEntityStatusForm extends ContentEntityConfirmFormBase {
       $form['unpublish_others'] = [
         '#type' => 'checkbox',
         '#title' => $this->t('Unpublish all other alerts.'),
-        '#default_value' => 1,
+        '#default_value' => 0,
       ];
 
       if (!empty($published_titles)) {


### PR DESCRIPTION
Fix #160.

This matches behaviour at BHCC.