### PR TITLE
Add alert banner workflow as role dependency

### DIFF
--- a/config/install/user.role.emergency_publisher.yml
+++ b/config/install/user.role.emergency_publisher.yml
@@ -4,6 +4,8 @@ dependencies:
   enforced:
     module:
       - localgov_alert_banner
+  config:
+   - workflows.workflow.localgov_alert_banners
 id: emergency_publisher
 label: 'Emergency publisher'
 weight: -2


### PR DESCRIPTION
Fix #203 

Add workflows.workflow.localgov_alert_banners config as a dependency to user.role.emergency_publisher role.
This is required to avoid error when installing the module under Drupal 10. 
It makes sure the alert banner workflow config is installed before installing the emergency publisher role.