### PR TITLE
Support for new entity permissions form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "minimum-stability": "dev",
     "license": "GPL-2.0-or-later",
     "require": {
-        "drupal/condition_field": "^2.0"
+        "drupal/condition_field": "^2.0",
+        "drupal/core": "^9.4 || ^10.0"
     },
     "require-dev": {
         "drupal/scheduled_transitions": "^2.1"

--- a/localgov_alert_banner.info.yml
+++ b/localgov_alert_banner.info.yml
@@ -1,7 +1,7 @@
 name: 'LocalGov Alert Banner'
 type: module
 description: 'Provides a sitewide alert banner for urgent alerts.'
-core_version_requirement: ^8.8 || ^9 || ^10
+core_version_requirement: ^9.4 || ^10
 package: LocalGov Drupal
 dependencies:
   - drupal:block

--- a/localgov_alert_banner.permissions.yml
+++ b/localgov_alert_banner.permissions.yml
@@ -23,4 +23,4 @@ manage all localgov alert banner entities:
 
 # Per bundle permissions.
 permission_callbacks:
-  - \Drupal\localgov_alert_banner\AlertBannerEntityPermissions::generatePermissions
+  - \Drupal\localgov_alert_banner\AlertBannerEntityPermissions::alertBannerTypePermissions

--- a/src/AlertBannerEntityPermissions.php
+++ b/src/AlertBannerEntityPermissions.php
@@ -2,33 +2,64 @@
 
 namespace Drupal\localgov_alert_banner;
 
+use Drupal\Core\Entity\BundlePermissionHandlerTrait;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\localgov_alert_banner\Entity\AlertBannerEntityType;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides dynamic permissions for Alert banner of different types.
  *
  * @ingroup localgov_alert_banner
  */
-class AlertBannerEntityPermissions {
+class AlertBannerEntityPermissions implements ContainerInjectionInterface {
 
+  use BundlePermissionHandlerTrait;
   use StringTranslationTrait;
 
   /**
-   * Returns an array of node type permissions.
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * MediaPermissions constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static($container->get('entity_type.manager'));
+  }
+
+  /**
+   * Returns an array of alert banner type permissions.
    *
    * @return array
-   *   The AlertBannerEntity by bundle permissions.
-   *   @see \Drupal\user\PermissionHandlerInterface::getPermissions()
+   *   The alert banner type permissions.
+   *
+   * @see \Drupal\user\PermissionHandlerInterface::getPermissions()
    */
-  public function generatePermissions() {
-    $perms = [];
-
-    foreach (AlertBannerEntityType::loadMultiple() as $type) {
-      $perms += $this->buildPermissions($type);
-    }
-
-    return $perms;
+  public function alertBannerTypePermissions() {
+    // Generate media permissions for all media types.
+    $alert_banner_types = $this->entityTypeManager
+      ->getStorage('localgov_alert_banner_type')
+      ->loadMultiple();
+    return $this->generatePermissions($alert_banner_types, [
+      $this,
+      'buildPermissions',
+    ]);
   }
 
   /**

--- a/src/AlertBannerEntityPermissions.php
+++ b/src/AlertBannerEntityPermissions.php
@@ -27,7 +27,7 @@ class AlertBannerEntityPermissions implements ContainerInjectionInterface {
   protected $entityTypeManager;
 
   /**
-   * MediaPermissions constructor.
+   * Alert banner permissions constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager service.

--- a/src/Entity/AlertBannerEntityType.php
+++ b/src/Entity/AlertBannerEntityType.php
@@ -26,6 +26,7 @@ use Drupal\user\RoleInterface;
  *     },
  *     "route_provider" = {
  *       "html" = "Drupal\localgov_alert_banner\AlertBannerEntityTypeHtmlRouteProvider",
+ *       "permissions" = "Drupal\user\Entity\EntityPermissionsRouteProvider",
  *     },
  *   },
  *   config_prefix = "localgov_alert_banner_type",
@@ -41,11 +42,12 @@ use Drupal\user\RoleInterface;
  *     "label"
  *   },
  *   links = {
- *     "canonical" = "/admin/structure/alert-banner-types/localgov_alert_banner_type/{localgov_alert_banner_type}",
- *     "add-form" = "/admin/structure/alert-banner-types/localgov_alert_banner_type/add",
- *     "edit-form" = "/admin/structure/alert-banner-types/localgov_alert_banner_type/{localgov_alert_banner_type}/edit",
- *     "delete-form" = "/admin/structure/alert-banner-types/localgov_alert_banner_type/{localgov_alert_banner_type}/delete",
- *     "collection" = "/admin/structure/alert-banner-types/localgov_alert_banner_type"
+ *     "canonical" = "/admin/structure/alert-banner-types/{localgov_alert_banner_type}",
+ *     "add-form" = "/admin/structure/alert-banner-types/add",
+ *     "edit-form" = "/admin/structure/alert-banner-types/{localgov_alert_banner_type}/edit",
+ *     "delete-form" = "/admin/structure/alert-banner-types/{localgov_alert_banner_type}/delete",
+ *     "entity-permissions-form" = "/admin/structure/alert-banner-types/{localgov_alert_banner_type}/permissions",
+ *     "collection" = "/admin/structure/alert-banner-types"
  *   }
  * )
  */

--- a/tests/src/Functional/PermissionsTest.php
+++ b/tests/src/Functional/PermissionsTest.php
@@ -106,7 +106,7 @@ class PermissionsTest extends BrowserTestBase {
     $this->assertSession()->statusCodeEquals(Response::HTTP_FORBIDDEN);
 
     // Check that anonymous user cannot access the alert banner types.
-    $this->drupalGet('admin/structure/alert-banner-types/localgov_alert_banner_type');
+    $this->drupalGet('admin/structure/alert-banner-types');
     $this->assertSession()->statusCodeEquals(Response::HTTP_FORBIDDEN);
 
     $normalAdminUser = $this->createUser(['access administration pages']);
@@ -139,7 +139,7 @@ class PermissionsTest extends BrowserTestBase {
     $this->assertSession()->statusCodeEquals(Response::HTTP_FORBIDDEN);
 
     // Check that authenticated user cannot access the alert banner types.
-    $this->drupalGet('admin/structure/alert-banner-types/localgov_alert_banner_type');
+    $this->drupalGet('admin/structure/alert-banner-types');
     $this->assertSession()->statusCodeEquals(Response::HTTP_FORBIDDEN);
 
     $this->drupalLogout();
@@ -176,7 +176,7 @@ class PermissionsTest extends BrowserTestBase {
     $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
 
     // Check that emergency publisher user cannot access the alert banner types.
-    $this->drupalGet('admin/structure/alert-banner-types/localgov_alert_banner_type');
+    $this->drupalGet('admin/structure/alert-banner-types');
     $this->assertSession()->statusCodeEquals(Response::HTTP_FORBIDDEN);
 
     $this->drupalLogout();
@@ -229,7 +229,7 @@ class PermissionsTest extends BrowserTestBase {
     $this->drupalLogin($adminUser);
 
     // Check that the admin user can access the alert banner types.
-    $this->drupalGet('admin/structure/alert-banner-types/localgov_alert_banner_type');
+    $this->drupalGet('admin/structure/alert-banner-types');
     $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
 
     // Check user access of the banner itself can be restricted.


### PR DESCRIPTION
Ref #218

Add new annotation to get the alert banner permissions form on the manage alert banner type
entity.
Also changes the alert banner permissions generator to make sure are assigned to the alert
banner entity using BundlePermissionHandlerTrait
