### PR TITLE
1.4.2 (or maybe 1.5?)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,7 @@
     "minimum-stability": "dev",
     "license": "GPL-2.0-or-later",
     "require": {
-        "drupal/condition_field": "^2.0",
-        "drupal/field_group": "~3.1"
+        "drupal/condition_field": "^2.0"
     },
     "require-dev": {
         "drupal/scheduled_transitions": "^2.1"

--- a/localgov_alert_banner.info.yml
+++ b/localgov_alert_banner.info.yml
@@ -7,7 +7,6 @@ dependencies:
   - drupal:block
   - drupal:content_moderation
   - drupal:field
-  - drupal:field_group
   - drupal:link
   - drupal:node
   - drupal:options

--- a/localgov_alert_banner.info.yml
+++ b/localgov_alert_banner.info.yml
@@ -1,7 +1,7 @@
 name: 'LocalGov Alert Banner'
 type: module
 description: 'Provides a sitewide alert banner for urgent alerts.'
-core_version_requirement: ^8.8 || ^9
+core_version_requirement: ^8.8 || ^9 || ^10
 package: LocalGov Drupal
 dependencies:
   - drupal:block

--- a/modules/localgov_alert_banner_full_page/localgov_alert_banner_full_page.info.yml
+++ b/modules/localgov_alert_banner_full_page/localgov_alert_banner_full_page.info.yml
@@ -1,12 +1,11 @@
 name: 'LocalGov Full page Alert Banner'
 type: module
 description: 'Provides a full page alert banner for urgent alerts.'
-core_version_requirement: ^8.8 || ^9
+core_version_requirement: ^8.8 || ^9 || ^10
 package: LocalGov Drupal
 dependencies:
   - drupal:block
   - drupal:field
-  - drupal:field_group
   - drupal:link
   - drupal:node
   - drupal:options


### PR DESCRIPTION
Minor update that adds official support for Drupal 10 to the alert banner.
(note: the full screen alert banner will need to wait until localgov_core formally supports Drupal 10).