### PR TITLE
Set the title colour for notable person messages

### DIFF
--- a/css/localgov-alert-banner.css
+++ b/css/localgov-alert-banner.css
@@ -60,6 +60,9 @@
 .localgov-alert-banner--notable-person {
   background-color: #000;
 }
+.localgov-alert-banner--notable-person .localgov-alert-banner__title {                                                                                        │
+  color: #fff;
+}
 
 .localgov-alert-banner__wrapper {
   max-width: 73.125rem;

--- a/css/localgov-alert-banner.css
+++ b/css/localgov-alert-banner.css
@@ -13,6 +13,11 @@
   color: #fefefe;
 }
 
+/* Reset the title colour as some themes assign a colour to h2 */
+.localgov-alert-banner .localgov-alert-banner__title {
+  color: inherit;
+}
+
 .localgov-alert-banner__close {
   padding: .5rem .9375rem;
   line-height: 1.5;
@@ -59,9 +64,6 @@
 /* Death of a notable person */
 .localgov-alert-banner--notable-person {
   background-color: #000;
-}
-.localgov-alert-banner--notable-person .localgov-alert-banner__title {                                                                                        │
-  color: #fff;
 }
 
 .localgov-alert-banner__wrapper {


### PR DESCRIPTION
When using the "Death of a notable person" alert type which sets a black background colour, the title - which is also set to black - isn't visible.

This PR sets an explicit text colour for the title within that alert type - ensuring that it can be seen and read.

I did consider opening this PR against the `localgov_base` theme but thought that it made more sense to do so within the alert banner module, although I'd be happy to re-submit it if needed.

## UI changes

Before:

![Screenshot 2022-10-24 at 01-12-20 Welcome! test](https://user-images.githubusercontent.com/339813/197471121-f6fb447f-be45-40fb-a419-740cb79b8c0c.png)

After:

![Screenshot 2022-10-24 at 01-18-37 Welcome! test](https://user-images.githubusercontent.com/339813/197471145-195f0f0f-426c-4f5b-9ca9-98ccde732667.png)