### PR TITLE
Reset the alert banner body text colour when using Olivero theme

### DIFF
--- a/css/localgov-alert-banner.css
+++ b/css/localgov-alert-banner.css
@@ -13,8 +13,11 @@
   color: #fefefe;
 }
 
-/* Reset the title colour as some themes assign a colour to h2 */
-.localgov-alert-banner .localgov-alert-banner__title {
+/* Reset the title colour as some themes assign a colour to h2.
+   Also reset the body text colour as Olivero assigns a colour 
+   to .text-content. */
+.localgov-alert-banner .localgov-alert-banner__title,
+.localgov-alert-banner .text-content {
   color: inherit;
 }
 


### PR DESCRIPTION
Apply the reset to .text-content class also.

Fix #227.

<img width="643" alt="Screenshot 2022-11-07 at 2 52 42 pm" src="https://user-images.githubusercontent.com/1467480/200340555-9ddcd008-9c78-45c5-a7f6-cbfee6286fe9.png">
