### PR TITLE
Replace classy with stark on alert banner functional tests

### DIFF
--- a/tests/src/Functional/AlertBannerBlockTest.php
+++ b/tests/src/Functional/AlertBannerBlockTest.php
@@ -13,7 +13,7 @@ class AlertBannerBlockTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected $defaultTheme = 'classy';
+  protected $defaultTheme = 'stark';
 
   /**
    * {@inheritdoc}

--- a/tests/src/Functional/PermissionsTest.php
+++ b/tests/src/Functional/PermissionsTest.php
@@ -14,7 +14,7 @@ class PermissionsTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected $defaultTheme = 'classy';
+  protected $defaultTheme = 'stark';
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
Classy no longer enabled on Drupal 10

Ref #233 which this is a part fix
