### PR TITLE
Default minor alter banner hide button hover background to black

### DIFF
--- a/css/localgov-alert-banner.css
+++ b/css/localgov-alert-banner.css
@@ -43,6 +43,14 @@
   background-color: #fff;
   border-color: #fff;
   color: #0b0c0c;
+  cursor: pointer;
+}
+
+.localgov-alert-banner--minor .localgov-alert-banner__close:focus,
+.localgov-alert-banner--minor .localgov-alert-banner__close:hover {
+  background-color: #0b0c0c;
+  border-color: #0b0c0c;
+  color: #fff;
 }
 
 /* Announcement */


### PR DESCRIPTION
Fix #238

Matches the localgov_base fix for other themes to fix accessibility contrast issue.
Also adds pointer to hide button.
