### PR TITLE
Replaces link assignment when no custom text is provided

### DIFF
--- a/localgov_alert_banner.page.inc
+++ b/localgov_alert_banner.page.inc
@@ -35,8 +35,11 @@ function template_preprocess_localgov_alert_banner(array &$variables) {
 
   // Set default link text if field exists.
   if ($entity->hasField('link')) {
-    if ($entity->get('link')->title === '') {
-      $variables['content']['link'] = Link::fromTextAndUrl(t('More information'), Url::fromUri($entity->get('link')->uri))->toString();
+    $link = $entity->get('link');
+    if ($link->title === '') {
+      $link_value = $link->getValue();
+      $link_value[0]['title'] = t('More information');
+      $entity->set('link', $link_value);
     }
   }
 


### PR DESCRIPTION
- The original code *changes* the type of the render array from LinkItem to GeneratedLink.
- This makes theming the entity slightly unpredictable.
- This change supplies the default text *without* changing the type of object provided to Twig.
- Re: #245

So this _does_ fix the issue, _and_ works as expected in e.g. `localgov_base`, but I don't know what to do for users who may have themed alert banner entities on the basis of the existing code. Feedback welcome :)