### PR TITLE
Skip alert type postsave during config sync and skip type of alert in block if not present

### DIFF
--- a/src/Entity/AlertBannerEntityType.php
+++ b/src/Entity/AlertBannerEntityType.php
@@ -71,7 +71,7 @@ class AlertBannerEntityType extends ConfigEntityBundleBase implements AlertBanne
   public function postSave(EntityStorageInterface $storage, $update = TRUE) {
 
     // Add fields and workflow when creating a new alert banner type.
-    if (!$update) {
+    if (!$update && !$this->isSyncing) {
 
       $bundle = $this->id();
       $config_directory = new FileStorage(__DIR__ . '/../../config/install');


### PR DESCRIPTION
Fix #251

During config sync operations, if creating a new alert banner type the visibility field will try to be created, even though that is part of config.

This checks if the isSyncing flag is set and skips over the postSave actions as we assume they are part of the config being imported.