### PR TITLE
Fix coding standards

### DIFF
--- a/localgov_alert_banner.install
+++ b/localgov_alert_banner.install
@@ -11,8 +11,8 @@ use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
-use Symfony\Component\Yaml\Yaml;
 use Drupal\user\RoleInterface;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Implements hook_install().

--- a/localgov_alert_banner.page.inc
+++ b/localgov_alert_banner.page.inc
@@ -7,8 +7,8 @@
  * Page callback for Alert banner entities.
  */
 
-use Drupal\Core\Render\Element;
 use Drupal\Core\Link;
+use Drupal\Core\Render\Element;
 use Drupal\Core\Url;
 
 /**

--- a/src/Access/AlertBannerEntityPageAccess.php
+++ b/src/Access/AlertBannerEntityPageAccess.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\localgov_alert_banner\Access;
 
-use Drupal\Core\Routing\Access\AccessInterface;
-use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Routing\Access\AccessInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
 
 /**
  * Checks access to alert banner entity pages.

--- a/src/AlertBannerEntityAccessControlHandler.php
+++ b/src/AlertBannerEntityAccessControlHandler.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\localgov_alert_banner;
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityAccessControlHandler;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\Access\AccessResult;
 
 /**
  * Access controller for the Alert banner entity.

--- a/src/AlertBannerEntityStorage.php
+++ b/src/AlertBannerEntityStorage.php
@@ -3,8 +3,8 @@
 namespace Drupal\localgov_alert_banner;
 
 use Drupal\Core\Entity\Sql\SqlContentEntityStorage;
-use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\localgov_alert_banner\Entity\AlertBannerEntityInterface;
 
 /**

--- a/src/AlertBannerEntityStorageInterface.php
+++ b/src/AlertBannerEntityStorageInterface.php
@@ -3,8 +3,8 @@
 namespace Drupal\localgov_alert_banner;
 
 use Drupal\Core\Entity\ContentEntityStorageInterface;
-use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\localgov_alert_banner\Entity\AlertBannerEntityInterface;
 
 /**

--- a/src/Controller/AlertBannerEntityController.php
+++ b/src/Controller/AlertBannerEntityController.php
@@ -5,8 +5,8 @@ namespace Drupal\localgov_alert_banner\Controller;
 use Drupal\Component\Utility\Xss;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
-use Drupal\Core\Url;
 use Drupal\Core\Link;
+use Drupal\Core\Url;
 use Drupal\localgov_alert_banner\Entity\AlertBannerEntityInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -4,13 +4,13 @@ namespace Drupal\localgov_alert_banner\Entity;
 
 use Drupal\condition_field\ConditionAccessResolver;
 use Drupal\Core\Cache\Cache;
-use Drupal\Core\Entity\EntityStorageInterface;
-use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Entity\EditorialContentEntityBase;
-use Drupal\Core\Entity\RevisionableInterface;
 use Drupal\Core\Entity\EntityChangedTrait;
 use Drupal\Core\Entity\EntityPublishedTrait;
+use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\RevisionableInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\user\UserInterface;
 
 /**

--- a/src/Entity/AlertBannerEntityInterface.php
+++ b/src/Entity/AlertBannerEntityInterface.php
@@ -3,9 +3,9 @@
 namespace Drupal\localgov_alert_banner\Entity;
 
 use Drupal\Core\Entity\ContentEntityInterface;
-use Drupal\Core\Entity\RevisionLogInterface;
 use Drupal\Core\Entity\EntityChangedInterface;
 use Drupal\Core\Entity\EntityPublishedInterface;
+use Drupal\Core\Entity\RevisionLogInterface;
 use Drupal\user\EntityOwnerInterface;
 
 /**

--- a/src/Entity/AlertBannerEntityType.php
+++ b/src/Entity/AlertBannerEntityType.php
@@ -7,8 +7,8 @@ use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
-use Drupal\workflows\Entity\Workflow;
 use Drupal\user\RoleInterface;
+use Drupal\workflows\Entity\Workflow;
 
 /**
  * Defines the Alert banner type entity.

--- a/src/Form/AlertBannerEntityStatusForm.php
+++ b/src/Form/AlertBannerEntityStatusForm.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\localgov_alert_banner\Form;
 
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Entity\ContentEntityConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\localgov_alert_banner\Entity\AlertBannerEntity;
 use Drupal\localgov_alert_banner\Entity\AlertBannerEntityInterface;
 

--- a/src/Plugin/Block/AlertBannerBlock.php
+++ b/src/Plugin/Block/AlertBannerBlock.php
@@ -2,14 +2,14 @@
 
 namespace Drupal\localgov_alert_banner\Plugin\Block;
 
+use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\Core\Session\AccountProxyInterface;
-use Drupal\Core\Block\BlockBase;
+use Drupal\field\Entity\FieldStorageConfig;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides the Alert banner block.

--- a/tests/src/Functional/AdminViewTest.php
+++ b/tests/src/Functional/AdminViewTest.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\Tests\localgov_alert_banner\Functional;
 
+use Drupal\Core\Url;
 use Drupal\Tests\BrowserTestBase;
 use Symfony\Component\HttpFoundation\Response;
-use Drupal\Core\Url;
 
 /**
  * Functional tests for LocalGovDrupal Alert banner admin view.

--- a/tests/src/Functional/PermissionsTest.php
+++ b/tests/src/Functional/PermissionsTest.php
@@ -3,8 +3,8 @@
 namespace Drupal\Tests\localgov_alert_banner\Functional;
 
 use Drupal\Tests\BrowserTestBase;
-use Symfony\Component\HttpFoundation\Response;
 use Drupal\user\RoleInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Functional tests for LocalGovDrupal Alert banner permissions.

--- a/tests/src/Kernel/SchedulingTest.php
+++ b/tests/src/Kernel/SchedulingTest.php
@@ -4,9 +4,9 @@ namespace Drupal\Tests\localgov_alert_banner\Kernel;
 
 use Drupal\Core\Extension\MissingDependencyException;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\scheduled_transitions\Entity\ScheduledTransition;
 use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
-use Drupal\scheduled_transitions\Entity\ScheduledTransition;
 
 /**
  * Kernel test for scheduling transitions.


### PR DESCRIPTION
Fix #259

Put use statements in alphabetical order.
