### PR TITLE
PR for 1.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "minimum-stability": "dev",
     "license": "GPL-2.0-or-later",
     "require": {
-        "drupal/condition_field": "^2.0"
+        "drupal/condition_field": "^2.0",
+        "drupal/core": "^9.4 || ^10.0"
     },
     "require-dev": {
         "drupal/scheduled_transitions": "^2.1"

--- a/localgov_alert_banner.info.yml
+++ b/localgov_alert_banner.info.yml
@@ -1,7 +1,7 @@
 name: 'LocalGov Alert Banner'
 type: module
 description: 'Provides a sitewide alert banner for urgent alerts.'
-core_version_requirement: ^8.8 || ^9 || ^10
+core_version_requirement: ^9.4 || ^10
 package: LocalGov Drupal
 dependencies:
   - drupal:block

--- a/localgov_alert_banner.install
+++ b/localgov_alert_banner.install
@@ -11,8 +11,8 @@ use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
-use Symfony\Component\Yaml\Yaml;
 use Drupal\user\RoleInterface;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Implements hook_install().

--- a/localgov_alert_banner.page.inc
+++ b/localgov_alert_banner.page.inc
@@ -7,8 +7,8 @@
  * Page callback for Alert banner entities.
  */
 
-use Drupal\Core\Render\Element;
 use Drupal\Core\Link;
+use Drupal\Core\Render\Element;
 use Drupal\Core\Url;
 
 /**

--- a/localgov_alert_banner.permissions.yml
+++ b/localgov_alert_banner.permissions.yml
@@ -23,4 +23,4 @@ manage all localgov alert banner entities:
 
 # Per bundle permissions.
 permission_callbacks:
-  - \Drupal\localgov_alert_banner\AlertBannerEntityPermissions::generatePermissions
+  - \Drupal\localgov_alert_banner\AlertBannerEntityPermissions::alertBannerTypePermissions

--- a/src/Access/AlertBannerEntityPageAccess.php
+++ b/src/Access/AlertBannerEntityPageAccess.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\localgov_alert_banner\Access;
 
-use Drupal\Core\Routing\Access\AccessInterface;
-use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Routing\Access\AccessInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
 
 /**
  * Checks access to alert banner entity pages.

--- a/src/AlertBannerEntityAccessControlHandler.php
+++ b/src/AlertBannerEntityAccessControlHandler.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\localgov_alert_banner;
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityAccessControlHandler;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\Access\AccessResult;
 
 /**
  * Access controller for the Alert banner entity.

--- a/src/AlertBannerEntityPermissions.php
+++ b/src/AlertBannerEntityPermissions.php
@@ -2,33 +2,64 @@
 
 namespace Drupal\localgov_alert_banner;
 
+use Drupal\Core\Entity\BundlePermissionHandlerTrait;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\localgov_alert_banner\Entity\AlertBannerEntityType;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides dynamic permissions for Alert banner of different types.
  *
  * @ingroup localgov_alert_banner
  */
-class AlertBannerEntityPermissions {
+class AlertBannerEntityPermissions implements ContainerInjectionInterface {
 
+  use BundlePermissionHandlerTrait;
   use StringTranslationTrait;
 
   /**
-   * Returns an array of node type permissions.
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * MediaPermissions constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static($container->get('entity_type.manager'));
+  }
+
+  /**
+   * Returns an array of alert banner type permissions.
    *
    * @return array
-   *   The AlertBannerEntity by bundle permissions.
-   *   @see \Drupal\user\PermissionHandlerInterface::getPermissions()
+   *   The alert banner type permissions.
+   *
+   * @see \Drupal\user\PermissionHandlerInterface::getPermissions()
    */
-  public function generatePermissions() {
-    $perms = [];
-
-    foreach (AlertBannerEntityType::loadMultiple() as $type) {
-      $perms += $this->buildPermissions($type);
-    }
-
-    return $perms;
+  public function alertBannerTypePermissions() {
+    // Generate media permissions for all media types.
+    $alert_banner_types = $this->entityTypeManager
+      ->getStorage('localgov_alert_banner_type')
+      ->loadMultiple();
+    return $this->generatePermissions($alert_banner_types, [
+      $this,
+      'buildPermissions',
+    ]);
   }
 
   /**

--- a/src/AlertBannerEntityPermissions.php
+++ b/src/AlertBannerEntityPermissions.php
@@ -27,7 +27,7 @@ class AlertBannerEntityPermissions implements ContainerInjectionInterface {
   protected $entityTypeManager;
 
   /**
-   * MediaPermissions constructor.
+   * Alert banner permissions constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager service.

--- a/src/AlertBannerEntityPermissions.php
+++ b/src/AlertBannerEntityPermissions.php
@@ -2,11 +2,11 @@
 
 namespace Drupal\localgov_alert_banner;
 
-use Drupal\Core\Entity\BundlePermissionHandlerTrait;
-use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\localgov_alert_banner\Entity\AlertBannerEntityType;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\BundlePermissionHandlerTrait;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\localgov_alert_banner\Entity\AlertBannerEntityType;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**

--- a/src/AlertBannerEntityStorage.php
+++ b/src/AlertBannerEntityStorage.php
@@ -3,8 +3,8 @@
 namespace Drupal\localgov_alert_banner;
 
 use Drupal\Core\Entity\Sql\SqlContentEntityStorage;
-use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\localgov_alert_banner\Entity\AlertBannerEntityInterface;
 
 /**

--- a/src/AlertBannerEntityStorageInterface.php
+++ b/src/AlertBannerEntityStorageInterface.php
@@ -3,8 +3,8 @@
 namespace Drupal\localgov_alert_banner;
 
 use Drupal\Core\Entity\ContentEntityStorageInterface;
-use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\localgov_alert_banner\Entity\AlertBannerEntityInterface;
 
 /**

--- a/src/Controller/AlertBannerEntityController.php
+++ b/src/Controller/AlertBannerEntityController.php
@@ -5,8 +5,8 @@ namespace Drupal\localgov_alert_banner\Controller;
 use Drupal\Component\Utility\Xss;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
-use Drupal\Core\Url;
 use Drupal\Core\Link;
+use Drupal\Core\Url;
 use Drupal\localgov_alert_banner\Entity\AlertBannerEntityInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -4,13 +4,13 @@ namespace Drupal\localgov_alert_banner\Entity;
 
 use Drupal\condition_field\ConditionAccessResolver;
 use Drupal\Core\Cache\Cache;
-use Drupal\Core\Entity\EntityStorageInterface;
-use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Entity\EditorialContentEntityBase;
-use Drupal\Core\Entity\RevisionableInterface;
 use Drupal\Core\Entity\EntityChangedTrait;
 use Drupal\Core\Entity\EntityPublishedTrait;
+use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\RevisionableInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\user\UserInterface;
 
 /**

--- a/src/Entity/AlertBannerEntityInterface.php
+++ b/src/Entity/AlertBannerEntityInterface.php
@@ -3,9 +3,9 @@
 namespace Drupal\localgov_alert_banner\Entity;
 
 use Drupal\Core\Entity\ContentEntityInterface;
-use Drupal\Core\Entity\RevisionLogInterface;
 use Drupal\Core\Entity\EntityChangedInterface;
 use Drupal\Core\Entity\EntityPublishedInterface;
+use Drupal\Core\Entity\RevisionLogInterface;
 use Drupal\user\EntityOwnerInterface;
 
 /**

--- a/src/Entity/AlertBannerEntityType.php
+++ b/src/Entity/AlertBannerEntityType.php
@@ -26,6 +26,7 @@ use Drupal\user\RoleInterface;
  *     },
  *     "route_provider" = {
  *       "html" = "Drupal\localgov_alert_banner\AlertBannerEntityTypeHtmlRouteProvider",
+ *       "permissions" = "Drupal\user\Entity\EntityPermissionsRouteProvider",
  *     },
  *   },
  *   config_prefix = "localgov_alert_banner_type",
@@ -41,11 +42,12 @@ use Drupal\user\RoleInterface;
  *     "label"
  *   },
  *   links = {
- *     "canonical" = "/admin/structure/alert-banner-types/localgov_alert_banner_type/{localgov_alert_banner_type}",
- *     "add-form" = "/admin/structure/alert-banner-types/localgov_alert_banner_type/add",
- *     "edit-form" = "/admin/structure/alert-banner-types/localgov_alert_banner_type/{localgov_alert_banner_type}/edit",
- *     "delete-form" = "/admin/structure/alert-banner-types/localgov_alert_banner_type/{localgov_alert_banner_type}/delete",
- *     "collection" = "/admin/structure/alert-banner-types/localgov_alert_banner_type"
+ *     "canonical" = "/admin/structure/alert-banner-types/{localgov_alert_banner_type}",
+ *     "add-form" = "/admin/structure/alert-banner-types/add",
+ *     "edit-form" = "/admin/structure/alert-banner-types/{localgov_alert_banner_type}/edit",
+ *     "delete-form" = "/admin/structure/alert-banner-types/{localgov_alert_banner_type}/delete",
+ *     "entity-permissions-form" = "/admin/structure/alert-banner-types/{localgov_alert_banner_type}/permissions",
+ *     "collection" = "/admin/structure/alert-banner-types"
  *   }
  * )
  */

--- a/src/Entity/AlertBannerEntityType.php
+++ b/src/Entity/AlertBannerEntityType.php
@@ -7,8 +7,8 @@ use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
-use Drupal\workflows\Entity\Workflow;
 use Drupal\user\RoleInterface;
+use Drupal\workflows\Entity\Workflow;
 
 /**
  * Defines the Alert banner type entity.

--- a/src/Form/AlertBannerEntityStatusForm.php
+++ b/src/Form/AlertBannerEntityStatusForm.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\localgov_alert_banner\Form;
 
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Entity\ContentEntityConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\localgov_alert_banner\Entity\AlertBannerEntity;
 use Drupal\localgov_alert_banner\Entity\AlertBannerEntityInterface;
 

--- a/src/Plugin/Block/AlertBannerBlock.php
+++ b/src/Plugin/Block/AlertBannerBlock.php
@@ -2,14 +2,14 @@
 
 namespace Drupal\localgov_alert_banner\Plugin\Block;
 
+use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\Core\Session\AccountProxyInterface;
-use Drupal\Core\Block\BlockBase;
+use Drupal\field\Entity\FieldStorageConfig;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides the Alert banner block.

--- a/tests/src/Functional/AdminViewTest.php
+++ b/tests/src/Functional/AdminViewTest.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\Tests\localgov_alert_banner\Functional;
 
+use Drupal\Core\Url;
 use Drupal\Tests\BrowserTestBase;
 use Symfony\Component\HttpFoundation\Response;
-use Drupal\Core\Url;
 
 /**
  * Functional tests for LocalGovDrupal Alert banner admin view.

--- a/tests/src/Functional/PermissionsTest.php
+++ b/tests/src/Functional/PermissionsTest.php
@@ -106,7 +106,7 @@ class PermissionsTest extends BrowserTestBase {
     $this->assertSession()->statusCodeEquals(Response::HTTP_FORBIDDEN);
 
     // Check that anonymous user cannot access the alert banner types.
-    $this->drupalGet('admin/structure/alert-banner-types/localgov_alert_banner_type');
+    $this->drupalGet('admin/structure/alert-banner-types');
     $this->assertSession()->statusCodeEquals(Response::HTTP_FORBIDDEN);
 
     $normalAdminUser = $this->createUser(['access administration pages']);
@@ -139,7 +139,7 @@ class PermissionsTest extends BrowserTestBase {
     $this->assertSession()->statusCodeEquals(Response::HTTP_FORBIDDEN);
 
     // Check that authenticated user cannot access the alert banner types.
-    $this->drupalGet('admin/structure/alert-banner-types/localgov_alert_banner_type');
+    $this->drupalGet('admin/structure/alert-banner-types');
     $this->assertSession()->statusCodeEquals(Response::HTTP_FORBIDDEN);
 
     $this->drupalLogout();
@@ -176,7 +176,7 @@ class PermissionsTest extends BrowserTestBase {
     $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
 
     // Check that emergency publisher user cannot access the alert banner types.
-    $this->drupalGet('admin/structure/alert-banner-types/localgov_alert_banner_type');
+    $this->drupalGet('admin/structure/alert-banner-types');
     $this->assertSession()->statusCodeEquals(Response::HTTP_FORBIDDEN);
 
     $this->drupalLogout();
@@ -229,7 +229,7 @@ class PermissionsTest extends BrowserTestBase {
     $this->drupalLogin($adminUser);
 
     // Check that the admin user can access the alert banner types.
-    $this->drupalGet('admin/structure/alert-banner-types/localgov_alert_banner_type');
+    $this->drupalGet('admin/structure/alert-banner-types');
     $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
 
     // Check user access of the banner itself can be restricted.

--- a/tests/src/Functional/PermissionsTest.php
+++ b/tests/src/Functional/PermissionsTest.php
@@ -3,8 +3,8 @@
 namespace Drupal\Tests\localgov_alert_banner\Functional;
 
 use Drupal\Tests\BrowserTestBase;
-use Symfony\Component\HttpFoundation\Response;
 use Drupal\user\RoleInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Functional tests for LocalGovDrupal Alert banner permissions.

--- a/tests/src/Kernel/SchedulingTest.php
+++ b/tests/src/Kernel/SchedulingTest.php
@@ -4,9 +4,9 @@ namespace Drupal\Tests\localgov_alert_banner\Kernel;
 
 use Drupal\Core\Extension\MissingDependencyException;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\scheduled_transitions\Entity\ScheduledTransition;
 use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
-use Drupal\scheduled_transitions\Entity\ScheduledTransition;
 
 /**
  * Kernel test for scheduling transitions.


### PR DESCRIPTION
- Support the Drupal permissions tab
- Drop support for Drupal 8, only support Drupal 9.4+ and Drupal 10.