### PR TITLE
Hide moderation controls when present on confirmation form page

### DIFF
--- a/localgov_alert_banner.module
+++ b/localgov_alert_banner.module
@@ -40,6 +40,13 @@ function localgov_alert_banner_preprocess(&$variables) {
     // Token as attribute.
     $variables['attributes']['data-dismiss-alert-token'] = $token;
 
+    // Remove the content moderation form if it is present.
+    // Do this only on the confirmation form page.
+    $route_match = \Drupal::routeMatch();
+    $route_name = $route_match->getRouteName();
+    if ($route_name == 'entity.localgov_alert_banner.status_form') {
+      unset($variables['content']['content_moderation_control']);
+    }
   }
 }
 


### PR DESCRIPTION
Fix #236

Adds a preprocess implementation to the alert banner to hide the moderation controls if they have been displayed when on the confirmation page (status form).

Note: This only hides on the confirmation form page eg.
/admin/content/alert-banner/18/status

If the form is included in another way it will still be present.

This way, moderation controls can be placed on an alert banner manage display if a site builder considers that desirable, without interfering with the confirmation form to put an alert banner live.
