### PR TITLE
Add enforced dependency on workflow

### DIFF
--- a/config/install/workflows.workflow.localgov_alert_banners.yml
+++ b/config/install/workflows.workflow.localgov_alert_banners.yml
@@ -5,6 +5,9 @@ dependencies:
     - localgov_alert_banner.localgov_alert_banner_type.localgov_alert_banner
   module:
     - content_moderation
+  enforced:
+    module:
+      - localgov_alert_banner    
 id: localgov_alert_banners
 label: 'Alert banners'
 type: content_moderation


### PR DESCRIPTION
fix #213

Uninstalling and reinstalling alert banner previously produced an error.  Now it uninstalls correctly.