### PR TITLE
Add the is_front template flag using path.matcher service

### DIFF
--- a/localgov_alert_banner.module
+++ b/localgov_alert_banner.module
@@ -47,6 +47,14 @@ function localgov_alert_banner_preprocess(&$variables) {
     if ($route_name == 'entity.localgov_alert_banner.status_form') {
       unset($variables['content']['content_moderation_control']);
     }
+
+    // Set is_front variable.
+    try {
+      $variables['is_front'] = \Drupal::service('path.matcher')->isFrontPage();
+    }
+    catch (Exception $e) {
+      $variables['is_front'] = FALSE;
+    }
   }
 }
 

--- a/tests/src/Functional/AlertBannerBlockTest.php
+++ b/tests/src/Functional/AlertBannerBlockTest.php
@@ -88,6 +88,14 @@ class AlertBannerBlockTest extends BrowserTestBase {
     // Load the front page and check the banner is displayed.
     $this->drupalGet('<front>');
     $this->assertSession()->pageTextContains($alert_message);
+
+    // Check that the front page class exists.
+    $this->assertSession()->responseContains('localgov-alert-banner--homepage');
+
+    // Check front pages class not visible on second page.
+    $this->drupalGet('/admin');
+    $this->assertSession()->responseContains('localgov-alert-banner');
+    $this->assertSession()->responseNotContains('localgov-alert-banner--homepage');
   }
 
   /**


### PR DESCRIPTION
Fix #279

Same method as page manager.
This adds the is_front template flag to localgov alert banner for testing with twig.
Will restore the default homepage class in the default template.
