### PR TITLE
Fix failing Hide alert banner test

### DIFF
--- a/tests/src/FunctionalJavascript/AlertBannerHideTest.php
+++ b/tests/src/FunctionalJavascript/AlertBannerHideTest.php
@@ -17,11 +17,6 @@ class AlertBannerHideTest extends WebDriverTestBase {
   /**
    * {@inheritdoc}
    */
-  protected $profile = 'localgov';
-
-  /**
-   * {@inheritdoc}
-   */
   protected static $modules = [
     'localgov_alert_banner',
   ];


### PR DESCRIPTION
Fix #282

Remove testing in default localgov profile
This is beause the profile is testing the home page, which with the profile
is now the user login page now that
https://github.com/localgovdrupal/localgov/pull/613
is merged means that is the user login page.
