### PR TITLE
Remove Drupal and drupalSettings from alert banner js

### DIFF
--- a/js/alert_banner.js
+++ b/js/alert_banner.js
@@ -5,7 +5,7 @@
  * This is so if the alert changes, the banner is reshown.
  */
 
-(function($, Drupal, drupalSettings, cookies) {
+(function($, cookies) {
 
   'use strict';
 
@@ -37,4 +37,4 @@
 
   });
 
-}) (jQuery, Drupal, drupalSettings, window.Cookies);
+}) (jQuery, window.Cookies);


### PR DESCRIPTION
Fix #284 

In Drupal 10 it was discovered that the core/drupal and drupalSettings arn't sent by default. They should be explicitlly declared as dependencies, however we don't actully use these so we can saftley remove them for now.