### PR TITLE
Remove revisions from local tasks as Drupal generates this link

### DIFF
--- a/localgov_alert_banner.links.task.yml
+++ b/localgov_alert_banner.links.task.yml
@@ -10,11 +10,6 @@ entity.localgov_alert_banner.edit_form:
   base_route: entity.localgov_alert_banner.canonical
   title: 'Edit'
 
-entity.localgov_alert_banner.version_history:
-  route_name: entity.localgov_alert_banner.version_history
-  base_route: entity.localgov_alert_banner.canonical
-  title: 'Revisions'
-
 entity.localgov_alert_banner.status_form:
   route_name: entity.localgov_alert_banner.status_form
   base_route: entity.localgov_alert_banner.canonical

--- a/localgov_alert_banner.links.task.yml
+++ b/localgov_alert_banner.links.task.yml
@@ -21,7 +21,7 @@ entity.localgov_alert_banner.delete_form:
   route_name: entity.localgov_alert_banner.delete_form
   base_route: entity.localgov_alert_banner.canonical
   title: Delete
-  weight: 10
+  weight: 20
 
 entity.localgov_alert_banner.collection:
   route_name: entity.localgov_alert_banner.collection


### PR DESCRIPTION
Fix #302

Removes the duplicated revisions tab at the top.
