### PR TITLE
fix: improve cumulative layout shift

### DIFF
--- a/js/alert_banner.js
+++ b/js/alert_banner.js
@@ -21,7 +21,6 @@
     var cookie_tokens = typeof cookie !== 'undefined' ? cookie.split('+') : [];
 
     $('.js-localgov-alert-banner').each(function() {
-      $(this).removeClass('hidden');
       var token = $(this).data('dismiss-alert-token');
       if ($.inArray(token, cookie_tokens) > -1) {
         $(this).hide();

--- a/localgov_alert_banner.module
+++ b/localgov_alert_banner.module
@@ -34,9 +34,6 @@ function localgov_alert_banner_preprocess(&$variables) {
     // Get token.
     $token = $variables['elements']['#localgov_alert_banner']->getToken();
 
-    // Add a hidden class.
-    $variables['attributes']['class'][] = 'hidden';
-
     // Token as attribute.
     $variables['attributes']['data-dismiss-alert-token'] = $token;
 


### PR DESCRIPTION
I've been investigating a CLS (Cumulative Layout Shift) in PageSpeed and ways to improve it; after some debugging I found it is coming from the alert banner module.

My understanding of how it renders from looking at the code is as follows;

1. A `hidden` class is added in `localgov_alert_banner.module` [here](https://github.com/localgovdrupal/localgov_alert_banner/blob/1.x/localgov_alert_banner.module#L38)
2. In the frontend, we find each alert banner, remove the `hidden` class, and then if it's in the user's cookie hide the alert [here](https://github.com/localgovdrupal/localgov_alert_banner/blob/1.x/js/alert_banner.js#L24).

Due to this, the use of `hidden` in step 1 and removing the class in step 2 is redundant and instead causes a large CLS chained onto the elements below it where we are hiding by default and then unhiding all the alert banners and then hiding again, this PR resolves this and doesn't hide the alerts unless they are in the user's cookie.

I've attached the before and after below;

**Before**
![Screenshot 2024-02-05 at 13 20 30](https://github.com/localgovdrupal/localgov_alert_banner/assets/8024370/00d7880d-6295-4f69-a689-9b595980b69c)

**After**
![Screenshot 2024-02-05 at 13 20 53](https://github.com/localgovdrupal/localgov_alert_banner/assets/8024370/fe16baa9-ad44-4653-b1d4-561e8adc0d0a)


cc: @markconroy to confirm my findings on this. 
