### PR TITLE
Fix Translation for alert banner not displaying

### DIFF
--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -250,14 +250,19 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
    *   True if the alert banner is visible, otherwise FALSE.
    */
   public function isVisible() {
+    $entity = $this;
+    $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    if ($langcode != 'en' && $this->hasTranslation($langcode)) {
+      $entity = $this->getTranslation($langcode);
+    }
 
     // Check if the field is present and has a value.
-    if (!$this->hasField('visibility') || $this->get('visibility')->isEmpty()) {
+    if (!$entity->hasField('visibility') || $entity->get('visibility')->isEmpty()) {
       return TRUE;
     }
 
     // Visibility condition config.
-    $conditions_config = $this->get('visibility')->getValue()[0]['conditions'];
+    $conditions_config = $entity->get('visibility')->getValue()[0]['conditions'];
 
     // Construct visibility conditions.
     $conditions = [];

--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -250,19 +250,14 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
    *   True if the alert banner is visible, otherwise FALSE.
    */
   public function isVisible() {
-    $entity = $this;
-    $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
-    if ($langcode != 'en' && $this->hasTranslation($langcode)) {
-      $entity = $this->getTranslation($langcode);
-    }
 
     // Check if the field is present and has a value.
-    if (!$entity->hasField('visibility') || $entity->get('visibility')->isEmpty()) {
+    if (!$this->hasField('visibility') || $this->get('visibility')->isEmpty()) {
       return TRUE;
     }
 
     // Visibility condition config.
-    $conditions_config = $entity->get('visibility')->getValue()[0]['conditions'];
+    $conditions_config = $this->get('visibility')->getValue()[0]['conditions'];
 
     // Construct visibility conditions.
     $conditions = [];
@@ -319,6 +314,7 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
       ->setLabel(t('Title'))
       ->setDescription(t('The title of the Alert banner.'))
       ->setRevisionable(TRUE)
+      ->setTranslatable(TRUE)
       ->setSettings([
         'max_length' => 50,
         'text_processing' => 0,

--- a/src/Plugin/Block/AlertBannerBlock.php
+++ b/src/Plugin/Block/AlertBannerBlock.php
@@ -4,9 +4,9 @@ namespace Drupal\localgov_alert_banner\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\field\Entity\FieldStorageConfig;
@@ -38,11 +38,11 @@ class AlertBannerBlock extends BlockBase implements ContainerFactoryPluginInterf
   protected $currentUser;
 
   /**
-   * The language manager service.
+   * The entity repository services.
    *
-   * @var \Drupal\Core\Language\LanguageManagerInterface
+   * @var \Drupal\Core\Entity\EntityRepositoryInterface
    */
-  protected $languageManager;
+  protected $entityRepository;
 
   /**
    * Constructs a new AlertBannerBlock.
@@ -57,14 +57,14 @@ class AlertBannerBlock extends BlockBase implements ContainerFactoryPluginInterf
    *   The entity type manager service.
    * @param \Drupal\Core\Session\AccountProxyInterface $current_user
    *   Current user service.
-   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
-   *   The language manager service.
+   * @param Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
+   *   The entity repository service.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountProxyInterface $current_user, LanguageManagerInterface $language_manager) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountProxyInterface $current_user, EntityRepositoryInterface $entity_repository) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;
     $this->currentUser = $current_user;
-    $this->languageManager = $language_manager;
+    $this->entityRepository = $entity_repository;
   }
 
   /**
@@ -88,7 +88,7 @@ class AlertBannerBlock extends BlockBase implements ContainerFactoryPluginInterf
       $plugin_definition,
       $container->get('entity_type.manager'),
       $container->get('current_user'),
-      $container->get('language_manager'),
+      $container->get('entity.repository'),
     );
   }
 
@@ -201,14 +201,9 @@ class AlertBannerBlock extends BlockBase implements ContainerFactoryPluginInterf
 
     // Load alert banners and add all.
     // Visibility check happens in build, so we get cache contexts on all.
-    $langcode = $this->languageManager->getCurrentLanguage()->getId();
     foreach ($published_alert_banners as $alert_banner_id) {
       $alert_banner = $this->entityTypeManager->getStorage('localgov_alert_banner')->load($alert_banner_id);
-
-      // Get alert banner translation if it exists.
-      if ($alert_banner->hasTranslation($langcode)) {
-        $alert_banner = $alert_banner->getTranslation($langcode);
-      }
+      $alert_banner = $this->entityRepository->getTranslationFromContext($alert_banner);
 
       $is_accessible = $alert_banner->access('view', $this->currentUser);
       if ($is_accessible) {

--- a/tests/src/Functional/TranslationsTest.php
+++ b/tests/src/Functional/TranslationsTest.php
@@ -6,6 +6,7 @@ use Drupal\block\Entity\Block;
 use Drupal\node\NodeInterface;
 use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\field\Entity\FieldConfig;
 use Drupal\Tests\BrowserTestBase;
 
 /**
@@ -25,7 +26,9 @@ class TranslationsTest extends BrowserTestBase {
    */
   protected static $modules = [
     'block',
+    'content_translation',
     'path',
+    'path_alias',
     'options',
     'node',
     'language',
@@ -48,6 +51,8 @@ class TranslationsTest extends BrowserTestBase {
 
     $this->drupalPlaceBlock('localgov_alert_banner_block');
     ConfigurableLanguage::createFromLangcode('zz')->save();
+    \Drupal::service('content_translation.manager')->setEnabled('localgov_alert_banner', 'localgov_alert_banner', TRUE);
+    FieldConfig::loadByName('localgov_alert_banner', 'localgov_alert_banner', 'short_description')->setTranslatable(TRUE)->save();
   }
 
   /**
@@ -66,7 +71,7 @@ class TranslationsTest extends BrowserTestBase {
       ->create([
         'type' => 'localgov_alert_banner',
         'title' => $alert_title,
-        // 'short_description' => $alert_body,
+        'short_description' => $alert_body,
         'type_of_alert' => 'minor',
         'moderation_state' => 'published',
         'langcode' => $default_langcode,
@@ -78,7 +83,7 @@ class TranslationsTest extends BrowserTestBase {
     $translated_alert_body = 'translated home page alert body - ' . $this->randomMachineName(32);
     $alert->addTranslation('zz', [
         'title' => $translated_alert_title,
-        // 'short_description' => $translated_alert_body,
+        'short_description' => $translated_alert_body,
         'type_of_alert' => 'minor',
         'moderation_state' => 'published',
       ])->save();
@@ -86,20 +91,18 @@ class TranslationsTest extends BrowserTestBase {
     // Test on home page.
     $this->drupalGet('<front>');
     $this->assertSession()->pageTextContains($alert_title);
-    // $this->assertSession()->pageTextContains($alert_body);
+    $this->assertSession()->pageTextContains($alert_body);
     $this->assertSession()->pageTextNotContains($translated_alert_title);
-    // $this->assertSession()->pageTextNotContains($translated_alert_body);
+    $this->assertSession()->pageTextNotContains($translated_alert_body);
 
     // Switch language.
+    $this->drupalGet('/zz');
 
     // Test correct translation on home page.
-    $this->drupalGet('/zz');
     $this->assertSession()->pageTextNotContains($alert_title);
-    // $this->assertSession()->pageTextNotContains($alert_body);
+    $this->assertSession()->pageTextNotContains($alert_body);
     $this->assertSession()->pageTextContains($translated_alert_title);
-    // $this->assertSession()->pageTextContains($translated_alert_body);
-
-    // Switch to default language.
+    $this->assertSession()->pageTextContains($translated_alert_body);
 
     // Create node.
     $this->drupalCreateContentType(array('type' => 'page'));
@@ -123,7 +126,7 @@ class TranslationsTest extends BrowserTestBase {
       ->create([
         'type' => 'localgov_alert_banner',
         'title' => $alert_title_node,
-        // 'short_description' => $alert_body_node,
+        'short_description' => $alert_body_node,
         'type_of_alert' => 'minor',
         'moderation_state' => 'published',
         'langcode' => $default_langcode,
@@ -143,35 +146,104 @@ class TranslationsTest extends BrowserTestBase {
     $translated_alert_body_node = 'translated node 1 alert body - ' . $this->randomMachineName(32);
     $node_alert->addTranslation('zz', [
         'title' => $translated_alert_title_node,
-        // 'short_description' => $translated_alert_body_node,
+        'short_description' => $translated_alert_body_node,
         'type_of_alert' => 'minor',
         'moderation_state' => 'published',
-        'visibility' => [
-          'conditions' => [
-            'request_path' => [
-              'pages' => '/node/1',
-              'negate' => 0,
-            ],
-          ],
-        ],
       ])->save();
 
-    // Go to node.
+    // Go to node in default language.
     $this->drupalGet('/node/1');
 
     // Test correct translation appears.
     $this->assertSession()->pageTextContains($alert_title_node);
-    // $this->assertSession()->pageTextContains($alert_body_node);
+    $this->assertSession()->pageTextContains($alert_body_node);
     $this->assertSession()->pageTextNotContains($translated_alert_title_node);
-    // $this->assertSession()->pageTextNotContains($translated_alert_body_node);
+    $this->assertSession()->pageTextNotContains($translated_alert_body_node);
 
     // Change language
     $this->drupalGet('/zz/node/1');
 
     // Test correct translation appears.
     $this->assertSession()->pageTextNotContains($alert_title_node);
-    // $this->assertSession()->pageTextNotContains($alert_body_node);
+    $this->assertSession()->pageTextNotContains($alert_body_node);
     $this->assertSession()->pageTextContains($translated_alert_title_node);
-    // $this->assertSession()->pageTextContains($translated_alert_body_node);
+    $this->assertSession()->pageTextContains($translated_alert_body_node);
+
+    // Create node with path.
+    $page = $this->createNode([
+      'type' => 'page',
+      'title' => $this->randomMachineName(8),
+      'status' => NodeInterface::PUBLISHED,
+      'langcode' => $default_langcode,
+    ]);
+    $this->container->get('entity_type.manager')->getStorage('path_alias')->create([
+      'path' => '/node/' . $page->id(),
+      'alias' => '/untranslated-path',
+      'langcode' => $default_langcode,
+    ])->save();
+
+    // Add node translation.
+    $translated_page = $page->addTranslation('zz', [
+      'title' => $this->randomMachineName(8),
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $this->container->get('entity_type.manager')->getStorage('path_alias')->create([
+      'path' => '/node/' . $page->id(),
+      'alias' => '/translated-path',
+      'langcode' => 'zz',
+    ])->save();
+
+    // Enable translation of the visibility field.
+    FieldConfig::loadByName('localgov_alert_banner', 'localgov_alert_banner', 'visibility')->setTranslatable(TRUE)->save();
+
+    // Create banner with page restriction.
+    $alert_title_pa_node = 'path alias page alert title - ' . $this->randomMachineName(8);
+    $alert_body_pa_node = 'path alias page alert body - ' . $this->randomMachineName(32);
+    $pa_node_alert = $this->container->get('entity_type.manager')->getStorage('localgov_alert_banner')
+      ->create([
+        'type' => 'localgov_alert_banner',
+        'title' => $alert_title_pa_node,
+        'short_description' => $alert_body_pa_node,
+        'type_of_alert' => 'minor',
+        'moderation_state' => 'published',
+        'langcode' => $default_langcode,
+        'visibility' => [
+          'conditions' => [
+            'request_path' => [
+              'pages' => '/untranslated-path',
+              'negate' => 0,
+            ],
+          ],
+        ],
+      ]);
+    $node_alert->save();
+
+    // Translate banner with page restriction.
+    $translated_alert_title_pa_node = 'translated path alias page alert title - ' . $this->randomMachineName(8);
+    $translated_alert_body_pa_node = 'translated path alias page alert body - ' . $this->randomMachineName(32);
+    $pa_node_alert->addTranslation('zz', [
+        'title' => $translated_alert_title_pa_node,
+        'short_description' => $translated_alert_body_pa_node,
+        'type_of_alert' => 'minor',
+        'moderation_state' => 'published',
+      ])->save();
+
+    // Go to node in default language.
+    $this->drupalGet('/untranslated-path');
+
+    // Test correct translation appears.
+    $this->assertSession()->pageTextContains($alert_title_pa_node);
+    $this->assertSession()->pageTextContains($alert_body_pa_node);
+    $this->assertSession()->pageTextNotContains($translated_alert_title_pa_node);
+    $this->assertSession()->pageTextNotContains($translated_alert_body_pa_node);
+
+    // Change language
+    $this->drupalGet('/zz/translated-path');
+
+    // Test correct translation appears.
+    $this->assertSession()->pageTextNotContains($alert_title_pa_node);
+    $this->assertSession()->pageTextNotContains($alert_body_pa_node);
+    $this->assertSession()->pageTextContains($translated_alert_title_pa_node);
+    $this->assertSession()->pageTextContains($translated_alert_body_pa_node);
   }
 }

--- a/tests/src/Functional/TranslationsTest.php
+++ b/tests/src/Functional/TranslationsTest.php
@@ -2,12 +2,11 @@
 
 namespace Drupal\Tests\localgov_alert_banner\Functional;
 
-use Drupal\block\Entity\Block;
-use Drupal\node\NodeInterface;
-use Drupal\language\Entity\ConfigurableLanguage;
-use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\field\Entity\FieldConfig;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\node\NodeInterface;
 use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
 
 /**
  * Functional tests for LocalGovDrupal Alert banner block.
@@ -37,13 +36,6 @@ class TranslationsTest extends BrowserTestBase {
   ];
 
   /**
-   * A user with the 'administer blocks' permission.
-   *
-   * @var \Drupal\user\UserInterface
-   */
-  protected $adminUser;
-
-  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
@@ -51,18 +43,16 @@ class TranslationsTest extends BrowserTestBase {
 
     $this->drupalPlaceBlock('localgov_alert_banner_block');
     ConfigurableLanguage::createFromLangcode('zz')->save();
-    \Drupal::service('content_translation.manager')->setEnabled('localgov_alert_banner', 'localgov_alert_banner', TRUE);
+    $this->container->get('content_translation.manager')->setEnabled('localgov_alert_banner', 'localgov_alert_banner', TRUE);
     FieldConfig::loadByName('localgov_alert_banner', 'localgov_alert_banner', 'short_description')->setTranslatable(TRUE)->save();
   }
 
   /**
    * Test that valid translation is brought back based on current language.
-   *
-   * @return void
    */
   public function testAlertBannerTranslation(): void {
 
-    $default_langcode = \Drupal::service('language.default')->get()->getId();
+    $default_langcode = $this->container->get('language.default')->get()->getId();
 
     // Create alert banner.
     $alert_title = 'home page alert title - ' . $this->randomMachineName(8);
@@ -82,11 +72,11 @@ class TranslationsTest extends BrowserTestBase {
     $translated_alert_title = 'translated home page alert title - ' . $this->randomMachineName(8);
     $translated_alert_body = 'translated home page alert body - ' . $this->randomMachineName(32);
     $alert->addTranslation('zz', [
-        'title' => $translated_alert_title,
-        'short_description' => $translated_alert_body,
-        'type_of_alert' => 'minor',
-        'moderation_state' => 'published',
-      ])->save();
+      'title' => $translated_alert_title,
+      'short_description' => $translated_alert_body,
+      'type_of_alert' => 'minor',
+      'moderation_state' => 'published',
+    ])->save();
 
     // Test on home page.
     $this->drupalGet('<front>');
@@ -105,7 +95,7 @@ class TranslationsTest extends BrowserTestBase {
     $this->assertSession()->pageTextContains($translated_alert_body);
 
     // Create node.
-    $this->drupalCreateContentType(array('type' => 'page'));
+    $this->drupalCreateContentType(['type' => 'page']);
     $page = $this->createNode([
       'type' => 'page',
       'title' => $this->randomMachineName(8),
@@ -114,7 +104,7 @@ class TranslationsTest extends BrowserTestBase {
     ]);
 
     // Add node translation.
-    $translated_page = $page->addTranslation('zz', [
+    $page->addTranslation('zz', [
       'title' => $this->randomMachineName(8),
       'status' => NodeInterface::PUBLISHED,
     ]);
@@ -145,11 +135,11 @@ class TranslationsTest extends BrowserTestBase {
     $translated_alert_title_node = 'translated node 1 alert title - ' . $this->randomMachineName(8);
     $translated_alert_body_node = 'translated node 1 alert body - ' . $this->randomMachineName(32);
     $node_alert->addTranslation('zz', [
-        'title' => $translated_alert_title_node,
-        'short_description' => $translated_alert_body_node,
-        'type_of_alert' => 'minor',
-        'moderation_state' => 'published',
-      ])->save();
+      'title' => $translated_alert_title_node,
+      'short_description' => $translated_alert_body_node,
+      'type_of_alert' => 'minor',
+      'moderation_state' => 'published',
+    ])->save();
 
     // Go to node in default language.
     $this->drupalGet('/node/1');
@@ -160,7 +150,7 @@ class TranslationsTest extends BrowserTestBase {
     $this->assertSession()->pageTextNotContains($translated_alert_title_node);
     $this->assertSession()->pageTextNotContains($translated_alert_body_node);
 
-    // Change language
+    // Change language.
     $this->drupalGet('/zz/node/1');
 
     // Test correct translation appears.
@@ -183,7 +173,7 @@ class TranslationsTest extends BrowserTestBase {
     ])->save();
 
     // Add node translation.
-    $translated_page = $page->addTranslation('zz', [
+    $page->addTranslation('zz', [
       'title' => $this->randomMachineName(8),
       'status' => NodeInterface::PUBLISHED,
     ]);
@@ -222,11 +212,11 @@ class TranslationsTest extends BrowserTestBase {
     $translated_alert_title_pa_node = 'translated path alias page alert title - ' . $this->randomMachineName(8);
     $translated_alert_body_pa_node = 'translated path alias page alert body - ' . $this->randomMachineName(32);
     $pa_node_alert->addTranslation('zz', [
-        'title' => $translated_alert_title_pa_node,
-        'short_description' => $translated_alert_body_pa_node,
-        'type_of_alert' => 'minor',
-        'moderation_state' => 'published',
-      ])->save();
+      'title' => $translated_alert_title_pa_node,
+      'short_description' => $translated_alert_body_pa_node,
+      'type_of_alert' => 'minor',
+      'moderation_state' => 'published',
+    ])->save();
 
     // Go to node in default language.
     $this->drupalGet('/untranslated-path');
@@ -237,7 +227,7 @@ class TranslationsTest extends BrowserTestBase {
     $this->assertSession()->pageTextNotContains($translated_alert_title_pa_node);
     $this->assertSession()->pageTextNotContains($translated_alert_body_pa_node);
 
-    // Change language
+    // Change language.
     $this->drupalGet('/zz/translated-path');
 
     // Test correct translation appears.
@@ -246,4 +236,5 @@ class TranslationsTest extends BrowserTestBase {
     $this->assertSession()->pageTextContains($translated_alert_title_pa_node);
     $this->assertSession()->pageTextContains($translated_alert_body_pa_node);
   }
+
 }

--- a/tests/src/Functional/TranslationsTest.php
+++ b/tests/src/Functional/TranslationsTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Drupal\Tests\localgov_alert_banner\Functional;
+
+use Drupal\block\Entity\Block;
+use Drupal\node\NodeInterface;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Functional tests for LocalGovDrupal Alert banner block.
+ */
+class TranslationsTest extends BrowserTestBase {
+
+  use NodeCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'block',
+    'path',
+    'options',
+    'node',
+    'language',
+    'locale',
+    'localgov_alert_banner',
+  ];
+
+  /**
+   * A user with the 'administer blocks' permission.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $adminUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->drupalPlaceBlock('localgov_alert_banner_block');
+    ConfigurableLanguage::createFromLangcode('zz')->save();
+  }
+
+  /**
+   * Test that valid translation is brought back based on current language.
+   *
+   * @return void
+   */
+  public function testAlertBannerTranslation(): void {
+
+    $default_langcode = \Drupal::service('language.default')->get()->getId();
+
+    // Create alert banner.
+    $alert_title = 'home page alert title - ' . $this->randomMachineName(8);
+    $alert_body = 'home page alert body - ' . $this->randomMachineName(32);
+    $alert = $this->container->get('entity_type.manager')->getStorage('localgov_alert_banner')
+      ->create([
+        'type' => 'localgov_alert_banner',
+        'title' => $alert_title,
+        // 'short_description' => $alert_body,
+        'type_of_alert' => 'minor',
+        'moderation_state' => 'published',
+        'langcode' => $default_langcode,
+      ]);
+    $alert->save();
+
+    // Create translation.
+    $translated_alert_title = 'translated home page alert title - ' . $this->randomMachineName(8);
+    $translated_alert_body = 'translated home page alert body - ' . $this->randomMachineName(32);
+    $alert->addTranslation('zz', [
+        'title' => $translated_alert_title,
+        // 'short_description' => $translated_alert_body,
+        'type_of_alert' => 'minor',
+        'moderation_state' => 'published',
+      ])->save();
+
+    // Test on home page.
+    $this->drupalGet('<front>');
+    $this->assertSession()->pageTextContains($alert_title);
+    // $this->assertSession()->pageTextContains($alert_body);
+    $this->assertSession()->pageTextNotContains($translated_alert_title);
+    // $this->assertSession()->pageTextNotContains($translated_alert_body);
+
+    // Switch language.
+
+    // Test correct translation on home page.
+    $this->drupalGet('/zz');
+    $this->assertSession()->pageTextNotContains($alert_title);
+    // $this->assertSession()->pageTextNotContains($alert_body);
+    $this->assertSession()->pageTextContains($translated_alert_title);
+    // $this->assertSession()->pageTextContains($translated_alert_body);
+
+    // Switch to default language.
+
+    // Create node.
+    $this->drupalCreateContentType(array('type' => 'page'));
+    $page = $this->createNode([
+      'type' => 'page',
+      'title' => $this->randomMachineName(8),
+      'status' => NodeInterface::PUBLISHED,
+      'langcode' => $default_langcode,
+    ]);
+
+    // Add node translation.
+    $translated_page = $page->addTranslation('zz', [
+      'title' => $this->randomMachineName(8),
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+
+    // Create banner with page restriction.
+    $alert_title_node = 'node 1 alert title - ' . $this->randomMachineName(8);
+    $alert_body_node = 'node 1 alert body - ' . $this->randomMachineName(32);
+    $node_alert = $this->container->get('entity_type.manager')->getStorage('localgov_alert_banner')
+      ->create([
+        'type' => 'localgov_alert_banner',
+        'title' => $alert_title_node,
+        // 'short_description' => $alert_body_node,
+        'type_of_alert' => 'minor',
+        'moderation_state' => 'published',
+        'langcode' => $default_langcode,
+        'visibility' => [
+          'conditions' => [
+            'request_path' => [
+              'pages' => '/node/1',
+              'negate' => 0,
+            ],
+          ],
+        ],
+      ]);
+    $node_alert->save();
+
+    // Translate banner with page restriction.
+    $translated_alert_title_node = 'translated node 1 alert title - ' . $this->randomMachineName(8);
+    $translated_alert_body_node = 'translated node 1 alert body - ' . $this->randomMachineName(32);
+    $node_alert->addTranslation('zz', [
+        'title' => $translated_alert_title_node,
+        // 'short_description' => $translated_alert_body_node,
+        'type_of_alert' => 'minor',
+        'moderation_state' => 'published',
+        'visibility' => [
+          'conditions' => [
+            'request_path' => [
+              'pages' => '/node/1',
+              'negate' => 0,
+            ],
+          ],
+        ],
+      ])->save();
+
+    // Go to node.
+    $this->drupalGet('/node/1');
+
+    // Test correct translation appears.
+    $this->assertSession()->pageTextContains($alert_title_node);
+    // $this->assertSession()->pageTextContains($alert_body_node);
+    $this->assertSession()->pageTextNotContains($translated_alert_title_node);
+    // $this->assertSession()->pageTextNotContains($translated_alert_body_node);
+
+    // Change language
+    $this->drupalGet('/zz/node/1');
+
+    // Test correct translation appears.
+    $this->assertSession()->pageTextNotContains($alert_title_node);
+    // $this->assertSession()->pageTextNotContains($alert_body_node);
+    $this->assertSession()->pageTextContains($translated_alert_title_node);
+    // $this->assertSession()->pageTextContains($translated_alert_body_node);
+  }
+}


### PR DESCRIPTION
Fix #318 

Alters the alert banner block to check for a translation, and add a translation test.

Originally authoured by [adinancenci](https://www.drupal.org/u/adinancenci).
Original patch in comment 3.
  https://www.drupal.org/project/localgov/issues/3427615#comment-15487385
(Patch originallty placed the logic in the entity, moved to block to fix issue with visibility checking).