### PR TITLE
fix: additional strict type fixes

### DIFF
--- a/src/Access/AlertBannerEntityPageAccess.php
+++ b/src/Access/AlertBannerEntityPageAccess.php
@@ -6,6 +6,7 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Routing\Access\AccessInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\localgov_alert_banner\Entity\AlertBannerEntity;
 
 /**
  * Checks access to alert banner entity pages.
@@ -22,14 +23,18 @@ class AlertBannerEntityPageAccess implements AccessInterface {
     if ($account->hasPermission('view all localgov alert banner entity pages')) {
       return AccessResult::allowed();
     }
-    elseif ($route_match->getParameters()->has('localgov_alert_banner') && $alert_banner = $route_match->getParameter('localgov_alert_banner')) {
-      $type_id = $alert_banner->bundle();
-      if ($account->hasPermission("view localgov alert banner $type_id pages")) {
-        return AccessResult::allowed();
+    elseif ($route_match->getParameters()->has('localgov_alert_banner')) {
+      $alert_banner = $route_match->getParameter('localgov_alert_banner');
+      if ($alert_banner instanceof AlertBannerEntity) {
+        $type_id = $alert_banner->bundle();
+        if ($account->hasPermission("view localgov alert banner $type_id pages")) {
+          return AccessResult::allowed();
+        }
+        else {
+          return AccessResult::forbidden();
+        }
       }
-      else {
-        return AccessResult::forbidden();
-      }
+      return AccessResult::neutral();
     }
     else {
       return AccessResult::neutral();

--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -149,7 +149,8 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
     }
 
     // Regenerate a JS token for the updated alert banner.
-    if ($this->get('status')->value) {
+    $status = (bool) $this->get('status')->value;
+    if ($status) {
       $prefix = 'alert-' . $this->id() . '-';
       $hash = sha1(uniqid('', TRUE));
       $this->setToken($prefix . '-' . $hash);

--- a/src/Form/AlertBannerEntityRevisionRevertTranslationForm.php
+++ b/src/Form/AlertBannerEntityRevisionRevertTranslationForm.php
@@ -90,7 +90,7 @@ class AlertBannerEntityRevisionRevertTranslationForm extends AlertBannerEntityRe
     $revision_translation = $revision->getTranslation($this->langcode);
 
     foreach ($latest_revision_translation->getFieldDefinitions() as $field_name => $definition) {
-      if ($definition->isTranslatable() || $revert_untranslated_fields) {
+      if ($definition->isTranslatable() || !is_null($revert_untranslated_fields)) {
         $latest_revision_translation->set($field_name, $revision_translation->get($field_name)->getValue());
       }
     }


### PR DESCRIPTION
Fixes the following errors, reported in https://github.com/localgovdrupal/localgov_project/pull/153

```
 ------ ---------------------------------------------------------------------------------- 
  Line   modules/contrib/localgov_alert_banner/src/Access/AlertBannerEntityPageAccess.php  
 ------ ---------------------------------------------------------------------------------- 
  25     Only booleans are allowed in &&, mixed given on the right side.                   
 ------ ---------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------ 
  Line   modules/contrib/localgov_alert_banner/src/Entity/AlertBannerEntity.php  
 ------ ------------------------------------------------------------------------ 
  152    Only booleans are allowed in an if condition, mixed given.              
 ------ ------------------------------------------------------------------------ 

 ------ --------------------------------------------------------------------------------------------------- 
  Line   modules/contrib/localgov_alert_banner/src/Form/AlertBannerEntityRevisionRevertTranslationForm.php  
 ------ --------------------------------------------------------------------------------------------------- 
  93     Only booleans are allowed in ||, mixed given on the right side.                                    
 ------ --------------------------------------------------------------------------------------------------- 
```