### PR TITLE
Remove default_argument_skip_url from group manage alert banners view

### DIFF
--- a/modules/group_alert_banner/config/optional/views.view.group_alert_banners.yml
+++ b/modules/group_alert_banner/config/optional/views.view.group_alert_banners.yml
@@ -624,7 +624,6 @@ display:
           default_argument_type: fixed
           default_argument_options:
             argument: ''
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true


### PR DESCRIPTION
Ref #334

Remove view default_argument_skip_url config key which is being removed.
See https://www.drupal.org/node/3382316
