### PR TITLE
Mark support for Drupal 11 and drop Drupal 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "drupal/condition_field": "^2.0",
-        "drupal/core": "^9.4 || ^10.0"
+        "drupal/core": "^10.0 || ^11.0"
     },
     "require-dev": {
         "drupal/group": "^3.2",
@@ -15,7 +15,7 @@
     },
     "suggest": {
         "drupal/scheduled_transitions": "Gives the ability to schedule the publishing and unpublishing of alert banners",
-        "localgovdrupal/localgov_core": "^1 || ^2",
+        "localgovdrupal/localgov_core": "Required by localgov_alert_banner_full_page sub module for localgov_media.",
         "drupal/group": "For Group integration."
     }
 }

--- a/localgov_alert_banner.info.yml
+++ b/localgov_alert_banner.info.yml
@@ -1,7 +1,7 @@
 name: 'LocalGov Alert Banner'
 type: module
 description: 'Provides a sitewide alert banner for urgent alerts.'
-core_version_requirement: ^9.4 || ^10
+core_version_requirement: ^10 || ^11
 package: LocalGov Drupal
 dependencies:
   - drupal:block

--- a/modules/group_alert_banner/group_alert_banner.info.yml
+++ b/modules/group_alert_banner/group_alert_banner.info.yml
@@ -2,7 +2,7 @@ name: 'Group Alert banner'
 type: module
 description: 'Enables Group functionality for Alert banners.'
 package: 'LocalGov Drupal'
-core_version_requirement: ^8.8 || ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - group:group
   - localgov_alert_banner:localgov_alert_banner

--- a/modules/localgov_alert_banner_full_page/localgov_alert_banner_full_page.info.yml
+++ b/modules/localgov_alert_banner_full_page/localgov_alert_banner_full_page.info.yml
@@ -1,7 +1,7 @@
 name: 'LocalGov Full page Alert Banner'
 type: module
 description: 'Provides a full page alert banner for urgent alerts.'
-core_version_requirement: ^8.8 || ^9 || ^10
+core_version_requirement: ^10 || ^11
 package: LocalGov Drupal
 dependencies:
   - drupal:block


### PR DESCRIPTION
~~In main module only.~~
Have marked all sub modules as Drupal 11 ready as they should all be installable now.

<img width="1406" alt="Screenshot 2024-07-23 at 12 15 34 PM" src="https://github.com/user-attachments/assets/257b9cc0-38de-4461-a492-f48e0a6ec15d">
