### PR TITLE
sets full-page alert banner to center align, adds ::backdrop

### DIFF
--- a/css/localgov-alert-banner.css
+++ b/css/localgov-alert-banner.css
@@ -8,13 +8,21 @@
   background-color: #00856A;
 }
 
+dialog.localgov-alert-banner {
+  margin: auto;
+}
+
+dialog.localgov-alert-banner::backdrop {
+  background-color: rgba(0, 0, 0, 0.8);
+}
+
 .localgov-alert-banner,
 .localgov-alert-banner a {
   color: #fefefe;
 }
 
 /* Reset the title colour as some themes assign a colour to h2.
-   Also reset the body text colour as Olivero assigns a colour 
+   Also reset the body text colour as Olivero assigns a colour
    to .text-content. */
 .localgov-alert-banner .localgov-alert-banner__title,
 .localgov-alert-banner .text-content {


### PR DESCRIPTION
Closes localgovdrupal/localgov_base#580 

## What does this change?

We have - in localgov_base - a CSS property for 

```
*,
*::before,
*::after {
  margin-top: 0;
}
```

This means in `localgov_base` our full page alert banner is placed horizontally centered, but vertically at the top since the default `margin: auto` for `dialog` is overridden.

It's worse for `localgov_scarfolk` since we have an override to say

```
.localgov-alert-banner {
  margin: var(--spacing);
}
```
This means the alert banner is at the top left of the page, with `1rem` of spacing around it. 

This PR adds the default `margin: auto` back to the alert banner if the banner is a dialog element.

It also adds a `::backdrop` property so we can have the rest of the page faded out behind the dialog.

## How to test

Create a full page alert banner, be delighted.

## Images
Before:

![Screenshot 2024-08-05 at 14 55 35](https://github.com/user-attachments/assets/5d6680bd-157b-425a-a29a-40584b20163a)


After:

![Screenshot 2024-08-05 at 15 37 03](https://github.com/user-attachments/assets/3080e320-24b7-43bf-b069-95fe28528abb)

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.