### PR TITLE
Fix the contrast on the type of alert text on full page alert banners

### DIFF
--- a/modules/localgov_alert_banner_full_page/css/full-page-alert-banner-layout.css
+++ b/modules/localgov_alert_banner_full_page/css/full-page-alert-banner-layout.css
@@ -22,9 +22,7 @@ dialog + .backdrop {
 	background: rgba(0, 0, 0, 1) !important;
 }
 
-.localgov-alert-banner-full h1,
-.localgov-alert-banner-full p,
-.localgov-alert-banner-full a {
+.localgov-alert-banner-full h1 {
 	color: inherit;
 }
 

--- a/modules/localgov_alert_banner_full_page/css/full-page-alert-banner-layout.css
+++ b/modules/localgov_alert_banner_full_page/css/full-page-alert-banner-layout.css
@@ -25,7 +25,7 @@ dialog + .backdrop {
 .localgov-alert-banner-full h1,
 .localgov-alert-banner-full p,
 .localgov-alert-banner-full a {
-	color: #FFFFFF;
+	color: inherit;
 }
 
 .localgov-alert-banner-full > .localgov-alert-banner-full--centered {


### PR DESCRIPTION
Fix #361

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Use color: inherit instead of overriding with a value

## How to test

Add a full page alert banner on each alert status and verify it has high contrast text (white on most banners, black on minor alert).
__Do this with theme set to Olivero or simmilar instead of localgov_base__

## How can we measure success?

Text on full page alerts is no longer low contrast.

## Have we considered potential risks?

Theme might be being overridden.

## Images

<img width="785" alt="Screenshot 2024-08-05 at 9 56 43 PM" src="https://github.com/user-attachments/assets/fcf1ab68-a202-4b3c-ac34-d0c7da214b18">
<img width="785" alt="Screenshot 2024-08-05 at 9 57 06 PM" src="https://github.com/user-attachments/assets/416672ed-7bf8-4e8e-a673-2da053e53d55">


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

Only testing contrast as that is the change in this PR.

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)