### PR TITLE
fix/1.x 363 emergency publisher perms

### DIFF
--- a/config/install/user.role.emergency_publisher.yml
+++ b/config/install/user.role.emergency_publisher.yml
@@ -11,7 +11,6 @@ label: 'Emergency publisher'
 weight: -2
 is_admin: null
 permissions:
-  - 'access administration pages'
   - 'access content overview'
   - 'access localgov alert banner listing page'
   - 'access toolbar'

--- a/config/install/user.role.emergency_publisher.yml
+++ b/config/install/user.role.emergency_publisher.yml
@@ -12,6 +12,7 @@ weight: -2
 is_admin: null
 permissions:
   - 'access administration pages'
+  - 'access content overview'
   - 'access localgov alert banner listing page'
   - 'access toolbar'
   - 'manage all localgov alert banner entities'

--- a/config/install/user.role.emergency_publisher.yml
+++ b/config/install/user.role.emergency_publisher.yml
@@ -13,8 +13,10 @@ is_admin: null
 permissions:
   - 'access administration pages'
   - 'access localgov alert banner listing page'
+  - 'access toolbar'
   - 'manage all localgov alert banner entities'
   - 'use localgov_alert_banners transition publish'
   - 'use localgov_alert_banners transition unpublish'
   - 'view all localgov alert banner entities'
   - 'view all localgov alert banner entity pages'
+  - 'view the administration theme'

--- a/config/install/user.role.emergency_publisher.yml
+++ b/config/install/user.role.emergency_publisher.yml
@@ -11,9 +11,7 @@ label: 'Emergency publisher'
 weight: -2
 is_admin: null
 permissions:
-  - 'access content overview'
   - 'access localgov alert banner listing page'
-  - 'access toolbar'
   - 'manage all localgov alert banner entities'
   - 'use localgov_alert_banners transition publish'
   - 'use localgov_alert_banners transition unpublish'

--- a/localgov_alert_banner.install
+++ b/localgov_alert_banner.install
@@ -19,14 +19,17 @@ use Symfony\Component\Yaml\Yaml;
  */
 function localgov_alert_banner_install($is_syncing) {
 
+  // Don't run this if syncing.
+  if ($is_syncing) {
+    return;
+  }
+
   // Configure scheduled transitions if enabled.
   if (\Drupal::moduleHandler()->moduleExists('scheduled_transitions')) {
     localgov_alert_banner_configure_scheduled_transitions();
   }
 
-  // Default grant permissions to view all alert banners.
-  user_role_grant_permissions(RoleInterface::ANONYMOUS_ID, ['view all localgov alert banner entities']);
-  user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, ['view all localgov alert banner entities']);
+  localgov_alert_banner_set_default_permissions();
 }
 
 /**

--- a/localgov_alert_banner.install
+++ b/localgov_alert_banner.install
@@ -219,3 +219,20 @@ function localgov_alert_banner_update_9002() {
     user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, ['view localgov alert banner ' . $bundle . ' entities']);
   }
 }
+
+/**
+ * Give emergency publisher permissions to access the alert banner manage screen
+ * from the toolbar.
+ */
+function localgov_alert_banner_update_10002() {
+  $module_handler = \Drupal::service('module_handler');
+  $perms[] = 'view the administration theme';
+  if ($module_handler->moduleExists('node')) {
+    $perms[] = 'access content overview';
+  }
+  if ($module_handler->moduleExists('toolbar')) {
+    $perms[] = 'access toolbar';
+  }
+  user_role_grant_permissions('emergency_publisher', $perms);
+  user_role_revoke_permissions('emergency_publisher', ['access administration pages']);
+}

--- a/localgov_alert_banner.install
+++ b/localgov_alert_banner.install
@@ -221,6 +221,8 @@ function localgov_alert_banner_update_9002() {
 }
 
 /**
+ * Assign additional permissions to Emergency publisher role.
+ *
  * Give emergency publisher permissions to access the alert banner manage screen
  * from the toolbar.
  */

--- a/localgov_alert_banner.module
+++ b/localgov_alert_banner.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\user\RoleInterface;
 
 /**
  * Implements hook_help().
@@ -149,6 +150,7 @@ function localgov_alert_banner_set_default_permissions() {
   user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, ['view all localgov alert banner entities']);
 
   // Set up emergency publisher access to toolbar if certian modules exist.
+  $perms = [];
   $module_handler = \Drupal::service('module_handler');
   if ($module_handler->moduleExists('node')) {
     $perms[] = 'access content overview';

--- a/localgov_alert_banner.module
+++ b/localgov_alert_banner.module
@@ -138,6 +138,28 @@ function localgov_alert_banner_configure_scheduled_transitions() {
 }
 
 /**
+ * Setup deafault permissions.
+ *
+ * @todo consider using hook_localgov_roles().
+ */
+function localgov_alert_banner_set_default_permissions() {
+
+  // Default grant permissions to view all alert banners.
+  user_role_grant_permissions(RoleInterface::ANONYMOUS_ID, ['view all localgov alert banner entities']);
+  user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, ['view all localgov alert banner entities']);
+
+  // Set up emergency publisher access to toolbar if certian modules exist.
+  $module_handler = \Drupal::service('module_handler');
+  if ($module_handler->moduleExists('node')) {
+    $perms[] = 'access content overview';
+  }
+  if ($module_handler->moduleExists('toolbar')) {
+    $perms[] = 'access toolbar';
+  }
+  user_role_grant_permissions('emergency_publisher', $perms);
+}
+
+/**
  * Implements hook_preprocess_field().
  */
 function localgov_alert_banner_preprocess_field(&$variables) {


### PR DESCRIPTION
- **Add access toolbar, view administation theme perms to emergeny publisher role**
- **Add access content overview permission**

Fix #363

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Adds the following permisions to the emergency publisher role

- 'access content overview'
- 'access toolbar'
- 'view the administration theme'

This is to allow users with just the emergency publisher role to access the manage alert banners screen from the toolbar menu.

## How to test

Create a user with just the emergency publisher role and check they can navigate to content -> alert banners in the top menu.

## How can we measure success?

Users with this role can now access the alert banners screen on default setup.

## Have we considered potential risks?

Gives access to access content overview, which they should'nt really need. Risk is small since typically those with this role would have access to that anyway. However since this PR is about those with just this role, it does give rise to asking if a seperate menu item should now be provided.

## Images

n/a

## Accessibility

n/a