### PR TITLE
[1.x] fix: add ignore next line

### DIFF
--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -151,6 +151,7 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
     // Regenerate a JS token for the updated alert banner.
     if ($this->get('status')->value) {
       $prefix = 'alert-' . $this->id() . '-';
+      // @phpstan-ignore-next-line Both sha1 and uniqid are safe to use in this context.
       $hash = sha1(uniqid('', TRUE));
       $this->setToken($prefix . '-' . $hash);
     }


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

This tells PHPStan to ignore the use of `sha1` and `uniqid` as we are only using for hashing