### PR TITLE
deprecate block contructor old signiture (current user and entity repository)

### DIFF
--- a/src/Plugin/Block/AlertBannerBlock.php
+++ b/src/Plugin/Block/AlertBannerBlock.php
@@ -4,9 +4,11 @@ namespace Drupal\localgov_alert_banner\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\localgov_alert_banner\AlertBannerManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -29,20 +31,6 @@ class AlertBannerBlock extends BlockBase implements ContainerFactoryPluginInterf
   protected $entityTypeManager;
 
   /**
-   * Current user service.
-   *
-   * @var \Drupal\Core\Session\AccountProxyInterface
-   */
-  protected $currentUser;
-
-  /**
-   * The entity repository services.
-   *
-   * @var \Drupal\Core\Entity\EntityRepositoryInterface
-   */
-  protected $entityRepository;
-
-  /**
    * The Localgov alert banner manager service.
    *
    * @var \Drupal\localgov_alert_banner\AlertBannerManagerInterface
@@ -60,13 +48,28 @@ class AlertBannerBlock extends BlockBase implements ContainerFactoryPluginInterf
    *   The plugin implementation definition.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager service.
-   * @param Drupal\localgov_alert_banner\AlertBannerManagerInterface $alert_banner_manager
+   * @param Drupal\localgov_alert_banner\AlertBannerManagerInterface|Drupal\Core\Session\AccountProxyInterfac $alert_banner_manager
    *   The localgov alert banner manager service.
+   * @param Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
+   *   The entity repository service.
+   *
+   * @see https://github.com/localgovdrupal/localgov_alert_banner/wiki/Change-to-alert-banner-block-signature
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AlertBannerManagerInterface $alert_banner_manager) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AlertBannerManagerInterface|AccountProxyInterface $alert_banner_manager, ?EntityRepositoryInterface $entity_repository = NULL) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;
     $this->alertBannerManager = $alert_banner_manager;
+    if ($alert_banner_manager instanceof AccountProxyInterface) {
+      // @codingStandardsIgnoreStart
+      @trigger_error('Calling ' . __CLASS__ . '::_construct() without the $alert_banner_manager argument is deprecated in localgov_alert_banner:1.8.0 and and it will be required in localgov_alert_banner:2.0.0. See https://github.com/localgovdrupal/localgov_alert_banner/wiki/Change-to-alert-banner-block-signature/', E_USER_DEPRECATED);
+      @trigger_error('Calling ' . __CLASS__ . '::_construct() with the $current_user argument is deprecated in localgov_alert_banner:1.8.0 and is removed from localgov_alert_banner:2.0.0. See https://github.com/localgovdrupal/localgov_alert_banner/wiki/Change-to-alert-banner-block-signature', E_USER_DEPRECATED);
+      $this->alertBannerManager = \Drupal::service('localgov_alert_banner.manager');
+      // @codingStandardsIgnoreEnd
+    }
+    if ($entity_repository instanceof EntityRepositoryInterface) {
+      // @codingStandardsIgnoreLine
+      @trigger_error('Calling ' . __CLASS__ . '::_construct() with the $entity_repository argument is deprecated in localgov_alert_banner:1.8.0 and is removed from localgov_alert_banner:2.0.0. See https://github.com/localgovdrupal/localgov_alert_banner/wiki/Change-to-alert-banner-block-signature', E_USER_DEPRECATED);
+    }
   }
 
   /**

--- a/src/Plugin/Block/AlertBannerBlock.php
+++ b/src/Plugin/Block/AlertBannerBlock.php
@@ -4,6 +4,7 @@ namespace Drupal\localgov_alert_banner\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\DependencyInjection\DeprecatedServicePropertyTrait;
 use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -22,6 +23,18 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * )
  */
 class AlertBannerBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  use DeprecatedServicePropertyTrait;
+
+  /**
+   * Defines deprecated injected properties.
+   *
+   * @var array
+   */
+  protected array $deprecatedProperties = [
+    'currentUser' => 'current_user',
+    'entityRepository' => 'entity.repository',
+  ];
 
   /**
    * The entity type manager service.


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Might not be neseccary, but if custom modules are extending the alert banner block, this will mark the old class signiture as deprecated. See https://github.com/localgovdrupal/localgov_alert_banner/wiki/Change-to-alert-banner-block-signature

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

Extend the block with the old signature and deprecation messages show up.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

Any custom modules get updated to the new signature

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

This might not be the right way of handling this, some people may not update to the new signature.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

<img width="704" alt="Screenshot 2024-08-29 at 11 14 11 pm" src="https://github.com/user-attachments/assets/463bb37e-ae37-4c44-9f14-51d8e7a7ad74">


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

n/a