### PR TITLE
Fix todos in admin view functional test

### DIFF
--- a/tests/src/Functional/AdminViewTest.php
+++ b/tests/src/Functional/AdminViewTest.php
@@ -47,8 +47,6 @@ class AdminViewTest extends BrowserTestBase {
    * Test load the alert banner admin view.
    */
   public function testLoadAdminView() {
-    // Create an admin user -- @todo move to set up.
-    $adminUser = $this->createUser([], 'admintestuser', TRUE);
     $this->drupalLogin($this->adminUser);
 
     // Check can access the admin view dashboard.
@@ -56,7 +54,6 @@ class AdminViewTest extends BrowserTestBase {
     $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
 
     // Check this is the view by making sure certian view only text is present.
-    // @todo Work out how to make sure this is the view path (Kernal test?).
     $this->assertSession()->responseContains('Manage Alert Banners');
 
     // Check that loading the collection URL loads the admin dashboard.

--- a/tests/src/Functional/AdminViewTest.php
+++ b/tests/src/Functional/AdminViewTest.php
@@ -17,6 +17,13 @@ class AdminViewTest extends BrowserTestBase {
   protected $defaultTheme = 'claro';
 
   /**
+   * Admin user.
+   *
+   * @var \Drupal\user\Entity\User|false
+   */
+  protected $adminUser;
+
+  /**
    * {@inheritdoc}
    */
   protected static $modules = [
@@ -24,12 +31,25 @@ class AdminViewTest extends BrowserTestBase {
   ];
 
   /**
+   * Test setup.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function setUp(): void
+  {
+    parent::setUp();
+
+    // Create an admin user.
+    $this->adminUser = $this->createUser([], 'admintestuser', true);
+  }
+
+  /**
    * Test load the alert banner admin view.
    */
   public function testLoadAdminView() {
     // Create an admin user -- @todo move to set up.
     $adminUser = $this->createUser([], 'admintestuser', TRUE);
-    $this->drupalLogin($adminUser);
+    $this->drupalLogin($this->adminUser);
 
     // Check can access the admin view dashboard.
     $this->drupalGet('admin/content/alert-banner');

--- a/tests/src/Functional/AdminViewTest.php
+++ b/tests/src/Functional/AdminViewTest.php
@@ -35,12 +35,11 @@ class AdminViewTest extends BrowserTestBase {
    *
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
-  protected function setUp(): void
-  {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create an admin user.
-    $this->adminUser = $this->createUser([], 'admintestuser', true);
+    $this->adminUser = $this->createUser([], 'admintestuser', TRUE);
   }
 
   /**

--- a/tests/src/Kernel/AdminViewUrlTest.php
+++ b/tests/src/Kernel/AdminViewUrlTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\Tests\localgov_alert_banner\Kernel;
+
+use Drupal\Core\Url;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\views\Views;
+
+/**
+ * Test admin view output.
+ *
+ * @group localgov_alert_banner
+ */
+class AdminViewUrlTest extends KernelTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'condition_field',
+    'content_moderation',
+    'field',
+    'link',
+    'localgov_alert_banner',
+    'options',
+    'system',
+    'text',
+    'user',
+    'views',
+    'workflows',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('content_moderation_state');
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('workflow');
+    $this->installEntitySchema('localgov_alert_banner');
+    $this->installConfig([
+      'content_moderation',
+      'system',
+      'localgov_alert_banner',
+      'user',
+    ]);
+  }
+
+  /**
+   * Test admin view output.
+   *
+   * @throws \Exception
+   */
+  public function testAdminViewUrl() :void {
+
+    $view = Views::getView('localgov_admin_manage_alert_banners');
+    $view->setDisplay('localgov_alert_banner_admin_list');
+
+    $view_url_route = $view->getUrl()->getRouteName();
+    $url = Url::fromRoute($view_url_route);
+
+    $this->assertEquals('/admin/content/alert-banner', $url->toString());
+  }
+
+}

--- a/tests/src/Kernel/AdminViewUrlTest.php
+++ b/tests/src/Kernel/AdminViewUrlTest.php
@@ -51,7 +51,7 @@ class AdminViewUrlTest extends KernelTestBase {
   }
 
   /**
-   * Test admin view output.
+   * Test admin view url.
    *
    * @throws \Exception
    */

--- a/tests/src/Kernel/AdminViewUrlTest.php
+++ b/tests/src/Kernel/AdminViewUrlTest.php
@@ -7,7 +7,7 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\views\Views;
 
 /**
- * Test admin view output.
+ * Test admin view url.
  *
  * @group localgov_alert_banner
  */


### PR DESCRIPTION
I noticed a couple of todos mentioned in the functional test AdminViewTest.

So I have moved the creation of the admin user into the setup function and added in a kernel test to confirm that the admin url that we are expecting is the one set on the manage alert banners view.
