### PR TITLE
Show type of alert in the alert banner

### DIFF
--- a/config/install/core.entity_view_display.localgov_alert_banner.localgov_alert_banner.default.yml
+++ b/config/install/core.entity_view_display.localgov_alert_banner.localgov_alert_banner.default.yml
@@ -33,7 +33,7 @@ content:
     type: link
     region: content
   short_description:
-    weight: 1
+    weight: 2
     label: hidden
     settings: {  }
     third_party_settings: {  }
@@ -47,8 +47,14 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
+  type_of_alert:
+    type: list_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
 hidden:
   content_moderation_control: true
-  type_of_alert: true
   uid: true
   visibility: true

--- a/templates/localgov-alert-banner.html.twig
+++ b/templates/localgov-alert-banner.html.twig
@@ -39,14 +39,23 @@
     <div class="localgov-alert-banner__inner">
       {# Begin Content #}
       <div class="localgov-alert-banner__content">
-        {% if display_title %}
-          <h2 class="localgov-alert-banner__title">
-            {{ content.title }}
-          </h2>
+        {% if display_title or content.type_of_alert %}
+          <header class="localgov-alert-banner__header">
+          {% if display_title %}
+            <h2 class="localgov-alert-banner__title">
+              {{ content.title }}
+            </h2>
+          {% endif %}
+          {% if content.type_of_alert %}
+            <p class="localgov-alert-banner__type-of-alert">
+              {{ content.type_of_alert }}
+            </p>
+          {% endif %}
+          </header>
         {% endif %}
 
         <div class="localgov-alert-banner__body">
-          {{ content|without('title', 'link') }}
+          {{ content|without('title', 'link', 'type_of_alert') }}
         </div>
 
         {% if has_link %}


### PR DESCRIPTION
Fix #345 

- **Support showing type of alert in the banner template**
- **Show the type of alert in the banner by default**

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Provides a default space in the template to show the output of type of alert. This uses a value from manage display, so it will only show if configured to do so. This will be the default in new installs only.

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

1. To fresh install
2. Choose a non localgov_base derived theme (localgov_base overrides the template).
3. Create an alert banner of each type
4. View alert banner, which should now show the type of alert.

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Fixes accesbility issue identified in #345 , allbeit in this case without the role as its just plain text.

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

This might not be the right solution, it won't effect current installs, it won't override existing themes.
However in this case it's more about providing an accessible default, as the issue identified in #345 is likley the themes responsibility?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

<img width="1191" alt="Screenshot 2024-09-09 at 9 17 18 PM" src="https://github.com/user-attachments/assets/8434c2cd-19b4-41ba-b22d-966c39c667ef">


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)