### PR TITLE
fix: coding standards

### DIFF
--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\localgov_alert_banner\Entity;
 
-use Drupal\condition_field\ConditionAccessResolver;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\EditorialContentEntityBase;
 use Drupal\Core\Entity\EntityChangedTrait;
@@ -11,6 +10,7 @@ use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\RevisionableInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\condition_field\ConditionAccessResolver;
 use Drupal\user\UserInterface;
 
 /**

--- a/src/Form/AlertBannerEntityRevisionDeleteForm.php
+++ b/src/Form/AlertBannerEntityRevisionDeleteForm.php
@@ -87,7 +87,7 @@ class AlertBannerEntityRevisionDeleteForm extends ConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, AlertBannerEntityInterface $localgov_alert_banner_revision = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, ?AlertBannerEntityInterface $localgov_alert_banner_revision = NULL) {
     $this->revision = $localgov_alert_banner_revision;
     $form = parent::buildForm($form, $form_state);
 

--- a/src/Form/AlertBannerEntityRevisionRevertForm.php
+++ b/src/Form/AlertBannerEntityRevisionRevertForm.php
@@ -94,7 +94,7 @@ class AlertBannerEntityRevisionRevertForm extends ConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, AlertBannerEntityInterface $localgov_alert_banner_revision = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, ?AlertBannerEntityInterface $localgov_alert_banner_revision = NULL) {
     $this->revision = $localgov_alert_banner_revision;
     $form = parent::buildForm($form, $form_state);
 

--- a/src/Plugin/Menu/LocalTask/StatusFormTab.php
+++ b/src/Plugin/Menu/LocalTask/StatusFormTab.php
@@ -18,7 +18,7 @@ class StatusFormTab extends LocalTaskDefault {
   /**
    * {@inheritdoc}
    */
-  public function getTitle(Request $request = NULL) {
+  public function getTitle(?Request $request = NULL) {
     $alert_banner = $request->attributes->get('localgov_alert_banner');
     if ($alert_banner instanceof AlertBannerEntityInterface) {
       $controller = new AlertBannerEntityController();

--- a/tests/src/Functional/AlertBannerBlockTest.php
+++ b/tests/src/Functional/AlertBannerBlockTest.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\Tests\localgov_alert_banner\Functional;
 
-use Drupal\block\Entity\Block;
 use Drupal\Tests\BrowserTestBase;
+use Drupal\block\Entity\Block;
 
 /**
  * Functional tests for LocalGovDrupal Alert banner block.

--- a/tests/src/Functional/AlertConfirmationTest.php
+++ b/tests/src/Functional/AlertConfirmationTest.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\Tests\localgov_alert_banner\Functional;
 
-use Drupal\localgov_alert_banner\Entity\AlertBannerEntity;
 use Drupal\Tests\BrowserTestBase;
+use Drupal\localgov_alert_banner\Entity\AlertBannerEntity;
 
 /**
  * Functional tests for LocalGovDrupal Alert banner confirmation form.

--- a/tests/src/Functional/TranslationsTest.php
+++ b/tests/src/Functional/TranslationsTest.php
@@ -2,11 +2,11 @@
 
 namespace Drupal\Tests\localgov_alert_banner\Functional;
 
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\node\NodeInterface;
-use Drupal\Tests\BrowserTestBase;
-use Drupal\Tests\node\Traits\NodeCreationTrait;
 
 /**
  * Functional tests for LocalGovDrupal Alert banner block.

--- a/tests/src/Functional/ViewsStatusLinkTest.php
+++ b/tests/src/Functional/ViewsStatusLinkTest.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\Tests\localgov_alert_banner\Functional;
 
-use Drupal\localgov_alert_banner\Entity\AlertBannerEntity;
 use Drupal\Tests\BrowserTestBase;
+use Drupal\localgov_alert_banner\Entity\AlertBannerEntity;
 
 /**
  * Tests the core Drupal\views\Plugin\views\StatusPageLink handler.

--- a/tests/src/Kernel/SchedulingTest.php
+++ b/tests/src/Kernel/SchedulingTest.php
@@ -4,9 +4,9 @@ namespace Drupal\Tests\localgov_alert_banner\Kernel;
 
 use Drupal\Core\Extension\MissingDependencyException;
 use Drupal\KernelTests\KernelTestBase;
-use Drupal\scheduled_transitions\Entity\ScheduledTransition;
 use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\scheduled_transitions\Entity\ScheduledTransition;
 
 /**
  * Kernel test for scheduling transitions.


### PR DESCRIPTION
Cherry-pick commit from @millnut https://github.com/localgovdrupal/localgov_alert_banner/commit/2377ed40b562eefc0b7f52082c2cb7aefc7c8cf9

So we can release on the 1.x branch.