### PR TITLE
Feature/201 remove jquery

### DIFF
--- a/js/alert_banner.js
+++ b/js/alert_banner.js
@@ -5,72 +5,69 @@
  * This is so if the alert changes, the banner is reshown.
  */
 
+function setAlertBannerHideCookie(cookieTokens, token) {
+  cookieTokens.push(token);
+  const newCookie = cookieTokens.join("+");
+  // Set expiry 30 days.
+  const expiry = Date.now() + 30 * 24 * 60 * 60 * 1000;
+  document.cookie = `hide-alert-banner-token=${newCookie}; expires=${new Date(
+    expiry
+  ).toUTCString()}; SameSite=Lax;`;
+}
+
 (function localgovAlertBannerScript(Drupal) {
   Drupal.behaviors.localgovAlertBanners = {
     attach(context) {
-      "use strict";
 
-      function setAlertBannerHideCookie(cookieTokens, token) {
-        cookieTokens.push(token);
-        const newCookie = cookieTokens.join("+");
-        // Set expiry 30 days.
-        const expiry = Date.now() + 30 * 24 * 60 * 60 * 1000;
-        document.cookie = `hide-alert-banner-token=${newCookie}; expires=${new Date(
-          expiry
-        ).toUTCString()}; SameSite=Lax;`;
+      const allCookies = document.cookie.split("; ");
+      let cookie;
+
+      for (let i = 0; i < allCookies.length; i++) {
+        const indvCookie = allCookies[i].split("=");
+        if (indvCookie[0] === "hide-alert-banner-token") {
+          cookie = indvCookie[1];
+        }
       }
 
-      document.addEventListener("DOMContentLoaded", function () {
-        const allCookies = document.cookie.split("; ");
-        let cookie;
+      const cookieTokens =
+        typeof cookie !== "undefined" ? cookie.split("+") : [];
 
-        for (let i = 0; i < allCookies.length; i++) {
-          const indvCookie = allCookies[i].split("=");
-          if (indvCookie[0] === "hide-alert-banner-token") {
-            cookie = indvCookie[1];
+      const alertBanners = once(
+        "allAlertBanners",
+        ".js-localgov-alert-banner",
+        context
+      );
+
+      if (alertBanners) {
+        alertBanners.forEach(function (banner) {
+          banner.classList.remove("hidden");
+          const token = banner.getAttribute("data-dismiss-alert-token");
+          if (cookieTokens.includes(token)) {
+            banner.style.display = "none";
           }
-        }
+        });
+      }
 
-        const cookieTokens =
-          typeof cookie !== "undefined" ? cookie.split("+") : [];
+      const alertBannerCloseButtons = once(
+        "allAlertBannerCloseButtons",
+        ".js-localgov-alert-banner__close",
+        context
+      );
 
-        const alertBanners = once(
-          "allAlertBanners",
-          ".js-localgov-alert-banner",
-          context
-        );
-
-        if (alertBanners) {
-          alertBanners.forEach(function (banner) {
-            banner.classList.remove("hidden");
-            const token = banner.getAttribute("data-dismiss-alert-token");
-            if (cookieTokens.includes(token)) {
-              banner.style.display = "none";
-            }
+      if (alertBannerCloseButtons) {
+        alertBannerCloseButtons.forEach(function (closeButton) {
+          closeButton.addEventListener("click", function (e) {
+            e.preventDefault();
+            const banner = closeButton.closest(".js-localgov-alert-banner");
+            banner.setAttribute("aria-hidden", "true");
+            banner.style.display = "none";
+            setAlertBannerHideCookie(
+              cookieTokens,
+              banner.getAttribute("data-dismiss-alert-token")
+            );
           });
-        }
-
-        const alertBannerCloseButtons = once(
-          "allAlertBannerCloseButtons",
-          ".js-localgov-alert-banner__close",
-          context
-        );
-
-        if (alertBannerCloseButtons) {
-          alertBannerCloseButtons.forEach(function (closeButton) {
-            closeButton.addEventListener("click", function (e) {
-              e.preventDefault();
-              const banner = closeButton.closest(".js-localgov-alert-banner");
-              banner.setAttribute("aria-hidden", "true");
-              banner.style.display = "none";
-              setAlertBannerHideCookie(
-                cookieTokens,
-                banner.getAttribute("data-dismiss-alert-token")
-              );
-            });
-          });
-        }
-      });
+        });
+      }
     },
   };
 })(Drupal);

--- a/localgov_alert_banner.libraries.yml
+++ b/localgov_alert_banner.libraries.yml
@@ -6,4 +6,5 @@ alert_banner:
   js:
     js/alert_banner.js: {}
   dependencies:
-    - core/jquery
+    - core/drupal
+    - core/once

--- a/modules/localgov_alert_banner_full_page/localgov_alert_banner_full_page.libraries.yml
+++ b/modules/localgov_alert_banner_full_page/localgov_alert_banner_full_page.libraries.yml
@@ -9,3 +9,4 @@ full_page_alert_banner:
   dependencies:
     - core/drupalSettings
     - localgov_alert_banner/alert_banner
+    - core/once

--- a/tests/src/FunctionalJavascript/AlertBannerHideTest.php
+++ b/tests/src/FunctionalJavascript/AlertBannerHideTest.php
@@ -45,11 +45,11 @@ class AlertBannerHideTest extends WebDriverTestBase {
 
     // Find and click hide link.
     $page = $this->getSession()->getPage();
-    // Ensure the button is correctly identified
+    // Ensure the button is correctly identified.
     $button = $this->assertSession()->elementExists('css', '.localgov-alert-banner__close');
-    // Wait for the button to be visible and interactive
+    // Wait for the button to be visible and interactive.
     $this->assertSession()->waitForElementVisible('css', '.localgov-alert-banner__close');
-    // Click the button
+    // Click the button.
     $button->click();
 
     // Check cookie set and banner not visible.

--- a/tests/src/FunctionalJavascript/AlertBannerHideTest.php
+++ b/tests/src/FunctionalJavascript/AlertBannerHideTest.php
@@ -43,12 +43,16 @@ class AlertBannerHideTest extends WebDriverTestBase {
     // Load the front page.
     $this->drupalGet('<front>');
 
+    // Wait for the button to be visible and interactive.
+    $this->assertSession()->waitForElementVisible('css', '.js-localgov-alert-banner__close');
+    // Ensure the button is correctly identified.
+    $this->assertSession()->elementExists('css', '.js-localgov-alert-banner__close');
+
     // Find and click hide link.
     $page = $this->getSession()->getPage();
-    // Ensure the button is correctly identified.
-    $button = $this->assertSession()->elementExists('css', '.localgov-alert-banner__close');
-    // Wait for the button to be visible and interactive.
-    $this->assertSession()->waitForElementVisible('css', '.localgov-alert-banner__close');
+
+    // Find the hide button.
+    $button = $page->findButton('Hide');
     // Click the button.
     $button->click();
 

--- a/tests/src/FunctionalJavascript/AlertBannerHideTest.php
+++ b/tests/src/FunctionalJavascript/AlertBannerHideTest.php
@@ -45,8 +45,11 @@ class AlertBannerHideTest extends WebDriverTestBase {
 
     // Find and click hide link.
     $page = $this->getSession()->getPage();
-    $button = $page->findButton('Hide');
-    $this->assertNotEmpty($button);
+    // Ensure the button is correctly identified
+    $button = $this->assertSession()->elementExists('css', '.localgov-alert-banner__close');
+    // Wait for the button to be visible and interactive
+    $this->assertSession()->waitForElementVisible('css', '.localgov-alert-banner__close');
+    // Click the button
     $button->click();
 
     // Check cookie set and banner not visible.


### PR DESCRIPTION
Closes #201 

## What does this change?

1. Removes jQuery
2. Add Drupal behaviour
3. Uses once() to get list of alert banners
4. Uses once() to get list of alert banner close buttons
5. Uses a template literal to write the `document.cookie`.

## How to test
Check that all the alert banners work as they currently do.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.