### PR TITLE
Check if emergency publisher role exists before changing permissions

### DIFF
--- a/localgov_alert_banner.install
+++ b/localgov_alert_banner.install
@@ -231,18 +231,18 @@ function localgov_alert_banner_update_9002() {
  * from the toolbar.
  */
 function localgov_alert_banner_update_10002() {
-$module_handler = \Drupal::service('module_handler');
+  $module_handler = \Drupal::service('module_handler');
 
-$perms[] = 'view the administration theme';
-if ($module_handler->moduleExists('node')) {
-  $perms[] = 'access content overview';
-}
-if ($module_handler->moduleExists('toolbar')) {
-  $perms[] = 'access toolbar';
-}
+  $perms[] = 'view the administration theme';
+  if ($module_handler->moduleExists('node')) {
+    $perms[] = 'access content overview';
+  }
+  if ($module_handler->moduleExists('toolbar')) {
+    $perms[] = 'access toolbar';
+  }
 
-// Add and revoke permissions if emergency publisher exists.
-if (Role::load('emergency_publisher') instanceof RoleInterface) {
+  // Add and revoke permissions if emergency publisher exists.
+  if (Role::load('emergency_publisher') instanceof RoleInterface) {
     user_role_grant_permissions('emergency_publisher', $perms);
     user_role_revoke_permissions('emergency_publisher', ['access administration pages']);
   }

--- a/localgov_alert_banner.install
+++ b/localgov_alert_banner.install
@@ -11,8 +11,10 @@ use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\user\Entity\Role;
 use Drupal\user\RoleInterface;
 use Symfony\Component\Yaml\Yaml;
+use Drupal\user\RoleInterface;
 
 /**
  * Implements hook_install().
@@ -230,14 +232,19 @@ function localgov_alert_banner_update_9002() {
  * from the toolbar.
  */
 function localgov_alert_banner_update_10002() {
-  $module_handler = \Drupal::service('module_handler');
-  $perms[] = 'view the administration theme';
-  if ($module_handler->moduleExists('node')) {
-    $perms[] = 'access content overview';
+$module_handler = \Drupal::service('module_handler');
+
+$perms[] = 'view the administration theme';
+if ($module_handler->moduleExists('node')) {
+  $perms[] = 'access content overview';
+}
+if ($module_handler->moduleExists('toolbar')) {
+  $perms[] = 'access toolbar';
+}
+
+// Add and revoke permissions if emergency publisher exists.
+if (Role::load('emergency_publisher) instanceof RoleInterface) {
+    user_role_grant_permissions('emergency_publisher', $perms);
+    user_role_revoke_permissions('emergency_publisher', ['access administration pages']);
   }
-  if ($module_handler->moduleExists('toolbar')) {
-    $perms[] = 'access toolbar';
-  }
-  user_role_grant_permissions('emergency_publisher', $perms);
-  user_role_revoke_permissions('emergency_publisher', ['access administration pages']);
 }

--- a/localgov_alert_banner.install
+++ b/localgov_alert_banner.install
@@ -14,7 +14,6 @@ use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\user\Entity\Role;
 use Drupal\user\RoleInterface;
 use Symfony\Component\Yaml\Yaml;
-use Drupal\user\RoleInterface;
 
 /**
  * Implements hook_install().
@@ -243,7 +242,7 @@ if ($module_handler->moduleExists('toolbar')) {
 }
 
 // Add and revoke permissions if emergency publisher exists.
-if (Role::load('emergency_publisher) instanceof RoleInterface) {
+if (Role::load('emergency_publisher') instanceof RoleInterface) {
     user_role_grant_permissions('emergency_publisher', $perms);
     user_role_revoke_permissions('emergency_publisher', ['access administration pages']);
   }


### PR DESCRIPTION
Fix #388

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fix bug reported in #386 

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

Install 1.7.10 and then delete the emergency publisher role.
You should still be able to run the latest DB update.

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Councils can install the update if they have removed the emergency publisher role.

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

Should be minimal, role might have changed permissions that need it.

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

n/a

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

n/a