### PR TITLE
Full page alert banner template

### DIFF
--- a/modules/localgov_alert_banner_full_page/css/full-page-alert-banner-layout.css
+++ b/modules/localgov_alert_banner_full_page/css/full-page-alert-banner-layout.css
@@ -3,32 +3,25 @@
  */
 
 .localgov-alert-banner-full::backdrop {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  background: rgba(0, 0, 0, 0.5);
 }
 
 .localgov-alert-banner-full.localgov-alert-banner--notable-person::backdrop {
   background: rgba(0, 0, 0, 1);
 }
 
-dialog.localgov-alert-banner-full.localgov-alert-banner--notable-person + .backdrop { /* Firefox handles backdrop differently */
-	background: rgba(0, 0, 0, 1) !important;
-}
-
-dialog + .backdrop {
-	background: rgba(0, 0, 0, 1) !important;
-}
-
 .localgov-alert-banner-full h1 {
 	color: inherit;
 }
 
-.localgov-alert-banner-full > .localgov-alert-banner-full--centered {
+.localgov-alert-banner-full > .localgov-alert-banner-full__centered {
   max-width: 62.5rem;
   margin: auto;
   overflow-x: none;
   overflow-y: auto;
+}
+
+.localgov-alert-banner-full__centered > * + *,
+.localgov-alert-banner-full__content > * + * {
+  margin-top: 1.5rem;
 }

--- a/modules/localgov_alert_banner_full_page/templates/localgov-alert-banner--localgov-full-page.html.twig
+++ b/modules/localgov_alert_banner_full_page/templates/localgov-alert-banner--localgov-full-page.html.twig
@@ -31,22 +31,33 @@
 
 <!-- Alert Banner-->
 <dialog {{ attributes.addClass(classes) }} aria-labelledby="{{ attributes.id }}-label" aria-describedby="{{ attributes.id }}-description">
-  <div role="document" class="localgov-alert-banner-full--centered">
+  <div role="document" class="localgov-alert-banner-full__centered">
+
     {% if not remove_hide_link %}
     <button id="{{ attributes.id }}-canceloverlay" class="localgov-alert-banner__close  js-localgov-alert-banner__close" aria-label="Close">
       {{ 'Close this dialog' | t }}
     </button>
     {% endif %}
-    <article class="localgov-alert-banner-full--content">
-      <h1 id="{{ attributes.id }}-label">{% if display_title %} {{ content.title }} {% endif %}</h1>
-      <div class="localgov-alert-banner-full--image">
-        {{ content.localgov_alert_banner_image }}
-      </div>
-      <div class="localgov-alert-banner-full--text" id="{{ attributes.id }}-description">
+
+    <article class="localgov-alert-banner-full__content">
+      {% if display_title %}
+        <h1 id="{{ attributes.id }}-label">{{ content.title }}</h1>
+        {% else %}
+        <h1 id="{{ attributes.id }}-label" class="visually-hidden">{{ content.title }}</h1>
+      {% endif %}
+
+      {% if content.localgov_alert_banner_image.0 %}
+        <div class="localgov-alert-banner-full__image">
+          {{ content.localgov_alert_banner_image }}
+        </div>
+      {% endif %}
+
+      <div class="localgov-alert-banner-full__text" id="{{ attributes.id }}-description">
         {{ content|without('link', 'title', 'localgov_alert_banner_image') }}
         {% if content.link %} {{ content.link }} {% endif %}
       </div>
     </article>
+
   </div>
 </dialog>
 <!-- End Alert Banner -->


### PR DESCRIPTION
Closes #373 

## What does this change?

- Adds `.visually-hidden` to title if title is set to not display (not perfect for a11y, but better than what we have)
- Checks for image before printing image div
- Removes Firefox-specific CSS that is not needed any more
- Adds CSS for better spacing between items

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.