### PR TITLE
Add a default block for the olivero theme

### DIFF
--- a/config/optional/block.block.localgov_alert_banner_olivero.yml
+++ b/config/optional/block.block.localgov_alert_banner_olivero.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - localgov_alert_banner
+  theme:
+    - olivero
+id: localgov_alert_banner_olivero
+theme: olivero
+region: hero
+weight: -100
+provider: null
+plugin: localgov_alert_banner_block
+settings:
+  id: localgov_alert_banner
+  label: 'Alert banner'
+  provider: localgov_alert_banner
+  label_display: '0'
+visibility: {  }


### PR DESCRIPTION
Fix #396

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Adds a default block for installation with the Olivero theme (default with Drupal)

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

Standard Drupal install, enable the localgov_alert_banner, add a banner.
The block should be in the Hero region.

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
Check it works!

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?
n/a
<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

<img width="1196" alt="Screenshot 2024-12-19 at 7 29 22 PM" src="https://github.com/user-attachments/assets/3b105dff-0aad-4077-8d4c-c1f83442e00d" />


<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

n/a