### PR TITLE
Fix alert banner cookie path

### DIFF
--- a/js/alert_banner.js
+++ b/js/alert_banner.js
@@ -12,7 +12,7 @@ function setAlertBannerHideCookie(cookieTokens, token) {
   const expiry = Date.now() + 30 * 24 * 60 * 60 * 1000;
   document.cookie = `hide-alert-banner-token=${newCookie}; expires=${new Date(
     expiry
-  ).toUTCString()}; SameSite=Lax;`;
+  ).toUTCString()}; path=/; SameSite=Lax;`;
 }
 
 (function localgovAlertBannerScript(Drupal) {

--- a/tests/src/FunctionalJavascript/AlertBannerHideTest.php
+++ b/tests/src/FunctionalJavascript/AlertBannerHideTest.php
@@ -61,7 +61,7 @@ class AlertBannerHideTest extends WebDriverTestBase {
     $this->assertSession()->pageTextNotContains($alert_message);
 
     // Test on login page.
-    $this->drupalGet('/user');
+    $this->drupalGet('/user/login');
     $this->assertSession()->pageTextNotContains($alert_message);
 
     // Update alert message.
@@ -130,10 +130,10 @@ class AlertBannerHideTest extends WebDriverTestBase {
       ]);
     $alert_3->save();
 
-    // Hide the banner on the /user page.
+    // Hide the banner on the /user/login page.
     // This is to test the cookie is set for the site and not just the path.
     // @see https://github.com/localgovdrupal/localgov_alert_banner/issues/401
-    $this->drupalGet('/user');
+    $this->drupalGet('/user/login');
     $page = $this->getSession()->getPage();
     $button_3 = $page->find('css', '[data-dismiss-alert-token="' . $alert_3->getToken() . '"] button');
     $button_3->click();

--- a/tests/src/FunctionalJavascript/AlertBannerHideTest.php
+++ b/tests/src/FunctionalJavascript/AlertBannerHideTest.php
@@ -117,6 +117,33 @@ class AlertBannerHideTest extends WebDriverTestBase {
     $this->assertSession()->pageTextNotContains($alert_message);
     $this->assertSession()->pageTextNotContains($alert_message_2);
 
+    // Set up a third alert banner.
+    $title_3 = $this->randomMachineName(8);
+    $alert_message_3 = 'Alert message: ' . $this->randomMachineName(16);
+    $alert_3 = $this->container->get('entity_type.manager')->getStorage('localgov_alert_banner')
+      ->create([
+        'type' => 'localgov_alert_banner',
+        'title' => $title_3,
+        'short_description' => $alert_message_3,
+        'type_of_alert' => 'minor',
+        'moderation_state' => 'published',
+      ]);
+    $alert_3->save();
+
+    // Hide the banner on the /user page.
+    // This is to test the cookie is set for the site and not just the path.
+    // @see https://github.com/localgovdrupal/localgov_alert_banner/issues/401
+    $this->drupalGet('/user');
+    $page = $this->getSession()->getPage();
+    $button_3 = $page->find('css', '[data-dismiss-alert-token="' . $alert_3->getToken() . '"] button');
+    $button_3->click();
+
+    // Reload home page.
+    $this->drupalGet('<front>');
+
+    // Test banner is not present.
+    $this->assertSession()->pageTextNotContains($alert_message_3);
+
   }
 
 }


### PR DESCRIPTION
Fix #401

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fix the regression wherby hiding an alert banner was hidden on a sub page, the banner would appear on the home page. This was becuase the cookie was not setting a path since the move away from js-cookie.

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

1. Set up a global alert baner (should be on all pages).
2. Go to any page that isn't the home page
3. Hide the banner
4. Go to home page

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Regression fixed.

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

N/a.

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->
