### PR TITLE
fix: return type hint spacing

### DIFF
--- a/src/Plugin/Block/AlertBannerBlock.php
+++ b/src/Plugin/Block/AlertBannerBlock.php
@@ -121,7 +121,7 @@ class AlertBannerBlock extends BlockBase implements ContainerFactoryPluginInterf
   /**
    * {@inheritdoc}
    */
-  public function blockForm($form, FormStateInterface $form_state) : array {
+  public function blockForm($form, FormStateInterface $form_state): array {
     $form = parent::blockForm($form, $form_state);
     $type_storage = $this->entityTypeManager->getStorage('localgov_alert_banner_type');
     $config = $this->getConfiguration();
@@ -181,7 +181,7 @@ class AlertBannerBlock extends BlockBase implements ContainerFactoryPluginInterf
    * @return array
    *   An array of alter banner type IDs as keys and values.
    */
-  protected function mapTypesConfigToQuery() : array {
+  protected function mapTypesConfigToQuery(): array {
     $include_types = $this->configuration['include_types'];
     return array_filter($include_types, function ($t) {
       return (bool) $t;

--- a/tests/src/Kernel/AdminViewUrlTest.php
+++ b/tests/src/Kernel/AdminViewUrlTest.php
@@ -55,7 +55,7 @@ class AdminViewUrlTest extends KernelTestBase {
    *
    * @throws \Exception
    */
-  public function testAdminViewUrl() :void {
+  public function testAdminViewUrl(): void {
 
     $view = Views::getView('localgov_admin_manage_alert_banners');
     $view->setDisplay('localgov_alert_banner_admin_list');


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fixes spacing issues with the return type hint. Getting ahead of these now before the Drupal coding standards change is implemented to check for this.