### PR TITLE
Rename Minor alert to Notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ LocalGov Drupal Alert banner module, adds a global alert banner block and entity
 
 ## Order of alerts
 
-In terms of order, it should be Notable Death -> Major -> Minor -> Announcement and then in date updated order.
+In terms of order, it should be Notable Death -> Emergency -> Notification -> Announcement and then in date updated order.
 
 ## Scheduling alert banners
 

--- a/config/install/field.storage.localgov_alert_banner.type_of_alert.yml
+++ b/config/install/field.storage.localgov_alert_banner.type_of_alert.yml
@@ -17,7 +17,7 @@ settings:
       label: Announcement
     -
       value: 20--minor
-      label: 'Minor alert'
+      label: 'Notification'
     -
       value: 50--major
       label: Emergency

--- a/localgov_alert_banner.install
+++ b/localgov_alert_banner.install
@@ -247,3 +247,28 @@ function localgov_alert_banner_update_10002() {
     user_role_revoke_permissions('emergency_publisher', ['access administration pages']);
   }
 }
+
+/**
+ * Update the type of alert label for 'Minor alert' to Notification if present.
+ */
+function localgov_alert_banner_update_10003() {
+
+  // Get the type of alert field storage configuration.
+  $type_of_alert_storage_config = FieldStorageConfig::loadByName('localgov_alert_banner', 'type_of_alert');
+  $settings = $type_of_alert_storage_config->get('settings');
+  
+  // Check if `allowed_values` 20--minor label is still 'Minor alert`
+  foreach($settings['allowed_values'] as $key => &$value) {
+    if ($key !== '20--minor') {
+      continue;
+    }
+    if ($value === 'Minor alert') {
+      // If so, update it's label to Notification.
+      $value = 'Notification';
+    }
+  }
+
+  // Save storage value.
+  $type_of_alert_storage_config->set('settings', $settings);
+  $type_of_alert_storage_config->save();
+}

--- a/localgov_alert_banner.install
+++ b/localgov_alert_banner.install
@@ -251,14 +251,14 @@ function localgov_alert_banner_update_10002() {
 /**
  * Update the type of alert label for 'Minor alert' to Notification if present.
  */
-function localgov_alert_banner_update_10003() {
+function localgov_alert_banner_update_10003(): void {
 
   // Get the type of alert field storage configuration.
   $type_of_alert_storage_config = FieldStorageConfig::loadByName('localgov_alert_banner', 'type_of_alert');
   $settings = $type_of_alert_storage_config->get('settings');
-  
-  // Check if `allowed_values` 20--minor label is still 'Minor alert`
-  foreach($settings['allowed_values'] as $key => &$value) {
+
+  // Check if `allowed_values` 20--minor label is still 'Minor alert`.
+  foreach ($settings['allowed_values'] as $key => &$value) {
     if ($key !== '20--minor') {
       continue;
     }


### PR DESCRIPTION
Fix #422

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Renames the label of the Type of alert for 'Minor alert' to 'Notification'.

Opening the PR so se can discuss the way forward. If we want to show the Type of alert on the front end of the banner for accessibility (as a label or screenreader) we need a public facing label. 

New installs would get the new label. An update hook is provided if users haven't updated the label already.
<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

The label of the alert banner should change to Notification.

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Label makes more sense when shown to end users.

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

Is it a sensible label?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

n/a

## Accessibility

n/a
(Though this PR is intended to unblock accessibility work as that needs to expose the label on the front end).
