### PR TITLE
fix: failing phpunit test due to changes in scheduled transitions module

### DIFF
--- a/tests/src/Kernel/SchedulingTest.php
+++ b/tests/src/Kernel/SchedulingTest.php
@@ -7,6 +7,7 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\scheduled_transitions\Entity\ScheduledTransition;
+use Drupal\user\Entity\User;
 
 /**
  * Kernel test for scheduling transitions.
@@ -77,6 +78,13 @@ class SchedulingTest extends KernelTestBase {
     $alert_banner_storage = $this->container->get('entity_type.manager')->getStorage('localgov_alert_banner');
     $runner = $this->container->get('scheduled_transitions.runner');
 
+    /** @var \Drupal\user\UserInterface $author */
+    $author = User::create([
+      'uid' => 2,
+      'name' => $this->randomMachineName(),
+    ]);
+    $author->save();
+
     // Create an alert banner.
     $alert_banner = $alert_banner_storage->create([
       'type' => 'localgov_alert_banner',
@@ -93,7 +101,7 @@ class SchedulingTest extends KernelTestBase {
     $scheduled_transition = ScheduledTransition::create([
       'entity' => $alert_banner,
       'entity_revision_id' => 1,
-      'author' => 1,
+      'author' => $author,
       'workflow' => 'localgov_alert_banners',
       'moderation_state' => 'published',
       'transition_on' => (new \DateTime('1 Jan 2020 12am'))->getTimestamp(),
@@ -108,13 +116,14 @@ class SchedulingTest extends KernelTestBase {
     $scheduled_transition = ScheduledTransition::create([
       'entity' => $alert_banner,
       'entity_revision_id' => 2,
-      'author' => 1,
+      'author' => $author,
       'workflow' => 'localgov_alert_banners',
       'moderation_state' => 'unpublished',
       'transition_on' => (new \DateTime('1 Jan 2021 12am'))->getTimestamp(),
     ]);
     $scheduled_transition->save();
     $runner->runTransition($scheduled_transition);
+    
     // It shouldn't be necessary to reset the cache after running a transition.
     $alert_banner_storage->resetCache([$alert_banner_id]);
     $alert_banner = $alert_banner_storage->load($alert_banner_id);

--- a/tests/src/Kernel/SchedulingTest.php
+++ b/tests/src/Kernel/SchedulingTest.php
@@ -123,7 +123,7 @@ class SchedulingTest extends KernelTestBase {
     ]);
     $scheduled_transition->save();
     $runner->runTransition($scheduled_transition);
-    
+
     // It shouldn't be necessary to reset the cache after running a transition.
     $alert_banner_storage->resetCache([$alert_banner_id]);
     $alert_banner = $alert_banner_storage->load($alert_banner_id);


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fixes #424 due to upstream changes to the scheduled transitions module (see https://www.drupal.org/project/scheduled_transitions/issues/3094322) and related test changes (https://git.drupalcode.org/project/scheduled_transitions/-/merge_requests/71/diffs#7ca217a4d73f18e3d48666e05a4867cf9f6e71b6)