### PR TITLE
fix: supress phpstan errors on drupal.org

### DIFF
--- a/modules/group_alert_banner/group_alert_banner.module
+++ b/modules/group_alert_banner/group_alert_banner.module
@@ -34,6 +34,7 @@ function group_alert_banner_localgov_microsites_roles_default() {
   $alert_banner_related_role_permissions = [
     // phpcs:disable Drupal.Classes.FullyQualifiedNamespace
     'global' => [
+      // @phpstan-ignore-next-line
       Drupal\localgov_microsites_group\RolesHelper::MICROSITES_CONTROLLER_ROLE => [
         'access localgov alert banner listing page',
         'use localgov_alert_banners transition create_new_draft',
@@ -42,6 +43,7 @@ function group_alert_banner_localgov_microsites_roles_default() {
         'view all localgov alert banner entities',
         'view all localgov alert banner entity pages',
       ],
+      // @phpstan-ignore-next-line
       Drupal\localgov_microsites_group\RolesHelper::MICROSITES_EDITOR_ROLE => [
         'access localgov alert banner listing page',
         'use localgov_alert_banners transition create_new_draft',
@@ -52,6 +54,7 @@ function group_alert_banner_localgov_microsites_roles_default() {
       ],
     ],
     'group' => [
+      // @phpstan-ignore-next-line
       Drupal\localgov_microsites_group\RolesHelper::GROUP_ADMIN_ROLE => [
         'access localgov_alert_banner overview',
         'create group_localgov_alert_banner:localgov_alert_banner entity',
@@ -68,13 +71,16 @@ function group_alert_banner_localgov_microsites_roles_default() {
         'view group_localgov_alert_banner:localgov_alert_banner relationship',
         'view any unpublished group_localgov_alert_banner:localgov_alert_banner entity',
       ],
+      // @phpstan-ignore-next-line
       Drupal\localgov_microsites_group\RolesHelper::GROUP_MEMBER_ROLE => [
         'access localgov_alert_banner overview',
         'view group_localgov_alert_banner:localgov_alert_banner entity',
       ],
+      // @phpstan-ignore-next-line
       Drupal\localgov_microsites_group\RolesHelper::GROUP_OUTSIDER_ROLE => [
         'view group_localgov_alert_banner:localgov_alert_banner entity',
       ],
+      // @phpstan-ignore-next-line
       Drupal\localgov_microsites_group\RolesHelper::GROUP_ANONYMOUS_ROLE => [
         'view group_localgov_alert_banner:localgov_alert_banner entity',
       ],


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

This will supress the PHPStan errors on Drupal.org due to localgov_microsites_group and it not being a composer dev dependency (https://git.drupalcode.org/project/localgov_alert_banner/-/jobs/6424731).

It is unlikely we'd want to have this module as a dev dependency due to the volume of other modules it would bring in.

**Workflow testing errors are not due to this PR and are fixed by https://github.com/localgovdrupal/localgov_alert_banner/pull/426**