### PR TITLE
fix: add return types and strict types

### DIFF
--- a/localgov_alert_banner.install
+++ b/localgov_alert_banner.install
@@ -5,6 +5,8 @@
  * LocalGov Alert Banner install file.
  */
 
+declare(strict_types=1);
+
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Config\Config;
 use Drupal\Core\Config\FileStorage;
@@ -18,7 +20,7 @@ use Symfony\Component\Yaml\Yaml;
 /**
  * Implements hook_install().
  */
-function localgov_alert_banner_install($is_syncing) {
+function localgov_alert_banner_install($is_syncing): void {
 
   // Don't run this if syncing.
   if ($is_syncing) {
@@ -36,7 +38,7 @@ function localgov_alert_banner_install($is_syncing) {
 /**
  * Update alert banner entity definition to include the token on the entity.
  */
-function localgov_alert_banner_update_8801() {
+function localgov_alert_banner_update_8801(): void {
   $field_storage_definition = BaseFieldDefinition::create('string')
     ->setSetting('max_length', 64)
     ->setDisplayConfigurable('form', FALSE)
@@ -49,7 +51,7 @@ function localgov_alert_banner_update_8801() {
 /**
  * Add visibility field to existing alert banners.
  */
-function localgov_alert_banner_update_8901() {
+function localgov_alert_banner_update_8901(): void {
 
   // Enable dependent condition_field module.
   \Drupal::service('module_installer')->install(['condition_field']);
@@ -93,7 +95,7 @@ function localgov_alert_banner_update_8901() {
 /**
  * Add workflow and configure scheduled transitions if enabled.
  */
-function localgov_alert_banner_update_9001() {
+function localgov_alert_banner_update_9001(): void {
 
   // Add localgov_alert_banner workflow config.
   $workflows_workflow_localgov_alert_banner = <<<EOY
@@ -212,7 +214,7 @@ EOY;
 /**
  * Add view alert banner permission to anonymous and authenticated users.
  */
-function localgov_alert_banner_update_9002() {
+function localgov_alert_banner_update_9002(): void {
   user_role_grant_permissions(RoleInterface::ANONYMOUS_ID, ['view all localgov alert banner entities']);
   user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, ['view all localgov alert banner entities']);
 
@@ -230,7 +232,7 @@ function localgov_alert_banner_update_9002() {
  * Give emergency publisher permissions to access the alert banner manage screen
  * from the toolbar.
  */
-function localgov_alert_banner_update_10002() {
+function localgov_alert_banner_update_10002(): void {
   $module_handler = \Drupal::service('module_handler');
 
   $perms[] = 'view the administration theme';

--- a/localgov_alert_banner.module
+++ b/localgov_alert_banner.module
@@ -5,6 +5,8 @@
  * Contains localgov_alert_banner.module.
  */
 
+declare(strict_types=1);
+
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\user\RoleInterface;
@@ -12,7 +14,7 @@ use Drupal\user\RoleInterface;
 /**
  * Implements hook_help().
  */
-function localgov_alert_banner_help($route_name, RouteMatchInterface $route_match) {
+function localgov_alert_banner_help($route_name, RouteMatchInterface $route_match): string|\Stringable|array|null {
   switch ($route_name) {
     // Main module help for the localgov_alert_banner module.
     case 'help.page.localgov_alert_banner':
@@ -22,13 +24,14 @@ function localgov_alert_banner_help($route_name, RouteMatchInterface $route_matc
       return $output;
 
     default:
+      return NULL;
   }
 }
 
 /**
  * Implements hook_preprocess_localgov_alert_banner().
  */
-function localgov_alert_banner_preprocess(&$variables) {
+function localgov_alert_banner_preprocess(&$variables): void {
 
   if (isset($variables['elements']['#localgov_alert_banner'])) {
 
@@ -62,7 +65,7 @@ function localgov_alert_banner_preprocess(&$variables) {
 /**
  * Implements hook_theme().
  */
-function localgov_alert_banner_theme() {
+function localgov_alert_banner_theme(): array {
   $theme = [];
   $theme['localgov_alert_banner'] = [
     'render element' => 'elements',
@@ -80,7 +83,7 @@ function localgov_alert_banner_theme() {
 /**
  * Implements hook_theme_suggestions_HOOK().
  */
-function localgov_alert_banner_theme_suggestions_localgov_alert_banner(array $variables) {
+function localgov_alert_banner_theme_suggestions_localgov_alert_banner(array $variables): array {
   $suggestions = [];
   $entity = $variables['elements']['#localgov_alert_banner'];
   $sanitized_view_mode = strtr($variables['elements']['#view_mode'], '.', '_');
@@ -96,7 +99,7 @@ function localgov_alert_banner_theme_suggestions_localgov_alert_banner(array $va
 /**
  * Implements hook_modules_installed().
  */
-function localgov_alert_banner_modules_installed($modules, $is_syncing) {
+function localgov_alert_banner_modules_installed($modules, $is_syncing): void {
 
   // Configure scheduled transitions if it's being installed.
   if (in_array('scheduled_transitions', $modules, TRUE)) {
@@ -107,7 +110,7 @@ function localgov_alert_banner_modules_installed($modules, $is_syncing) {
 /**
  * Configure scheduled transitions.
  */
-function localgov_alert_banner_configure_scheduled_transitions() {
+function localgov_alert_banner_configure_scheduled_transitions(): void {
 
   // Configure scheduled transitions for alert banners.
   $scheduled_transitions_config = \Drupal::service('config.factory')->getEditable('scheduled_transitions.settings');
@@ -143,7 +146,7 @@ function localgov_alert_banner_configure_scheduled_transitions() {
  *
  * @todo consider using hook_localgov_roles().
  */
-function localgov_alert_banner_set_default_permissions() {
+function localgov_alert_banner_set_default_permissions(): void {
 
   // Default grant permissions to view all alert banners.
   user_role_grant_permissions(RoleInterface::ANONYMOUS_ID, ['view all localgov alert banner entities']);
@@ -164,7 +167,7 @@ function localgov_alert_banner_set_default_permissions() {
 /**
  * Implements hook_preprocess_field().
  */
-function localgov_alert_banner_preprocess_field(&$variables) {
+function localgov_alert_banner_preprocess_field(&$variables): void {
   if ($variables['element']['#field_name'] == 'link' && $variables['element']['#bundle'] == 'localgov_alert_banner') {
     foreach ($variables['element']['#items'] as $item) {
       if (empty($item->getValue()['title'])) {
@@ -178,7 +181,7 @@ function localgov_alert_banner_preprocess_field(&$variables) {
 /**
  * Implements hook_gin_content_form_routes().
  */
-function localgov_alert_banner_gin_content_form_routes() {
+function localgov_alert_banner_gin_content_form_routes(): array {
   return [
     // Alert banner add form.
     'entity.localgov_alert_banner.add_form',

--- a/localgov_alert_banner.page.inc
+++ b/localgov_alert_banner.page.inc
@@ -7,6 +7,8 @@
  * Page callback for Alert banner entities.
  */
 
+declare(strict_types=1);
+
 use Drupal\Core\Render\Element;
 
 /**
@@ -21,7 +23,7 @@ use Drupal\Core\Render\Element;
  *   eg. To fetch the alert banner element,
  *   use variables['elements']['#localgov_alert_banner'].
  */
-function template_preprocess_localgov_alert_banner(array &$variables) {
+function template_preprocess_localgov_alert_banner(array &$variables): void {
 
   // Helpful $content variable for templates.
   foreach (Element::children($variables['elements']) as $key) {

--- a/modules/group_alert_banner/group_alert_banner.module
+++ b/modules/group_alert_banner/group_alert_banner.module
@@ -5,6 +5,8 @@
  * Various hook implementations.
  */
 
+declare(strict_types=1);
+
 use Drupal\Core\Block\BlockPluginInterface;
 use Drupal\Core\Database\Query\AlterableInterface;
 use Drupal\Core\Database\Query\SelectInterface;

--- a/modules/group_alert_banner/src/Plugin/Group/Relation/GroupAlertBanner.php
+++ b/modules/group_alert_banner/src/Plugin/Group/Relation/GroupAlertBanner.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\group_alert_banner\Plugin\Group\Relation;
 
 use Drupal\Core\Form\FormStateInterface;

--- a/modules/group_alert_banner/src/Plugin/Group/Relation/GroupAlertBannerDeriver.php
+++ b/modules/group_alert_banner/src/Plugin/Group/Relation/GroupAlertBannerDeriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\group_alert_banner\Plugin\Group\Relation;
 
 use Drupal\Component\Plugin\Derivative\DeriverBase;

--- a/modules/group_alert_banner/src/Routing/RouteSubscriber.php
+++ b/modules/group_alert_banner/src/Routing/RouteSubscriber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\group_alert_banner\Routing;
 
 use Drupal\Core\Routing\RouteSubscriberBase;

--- a/modules/group_alert_banner/tests/modules/group_alert_banner_test/group_alert_banner_test.module
+++ b/modules/group_alert_banner/tests/modules/group_alert_banner_test/group_alert_banner_test.module
@@ -4,3 +4,5 @@
  * @file
  * Various hook implementations.
  */
+
+declare(strict_types=1);

--- a/modules/group_alert_banner/tests/src/Kernel/GroupAlertBannerTest.php
+++ b/modules/group_alert_banner/tests/src/Kernel/GroupAlertBannerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\group_alert_banner\Kernel;
 
 use Drupal\Tests\group\Kernel\GroupKernelTestBase;

--- a/modules/localgov_alert_banner_full_page/localgov_alert_banner_full_page.install
+++ b/modules/localgov_alert_banner_full_page/localgov_alert_banner_full_page.install
@@ -7,12 +7,14 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
 /**
  * Implements hook_update_N().
  *
  * Hides the "Remove hide link" checkbox from Full page alert edit pages.
  */
-function localgov_alert_banner_full_page_update_9001() {
+function localgov_alert_banner_full_page_update_9001(): TranslatableMarkup|null {
 
   $form_display = Drupal::service('entity_type.manager')
     ->getStorage('entity_form_display')
@@ -28,4 +30,6 @@ function localgov_alert_banner_full_page_update_9001() {
   else {
     return t('Cannot find settings for the "Remove hide link" checkbox.');
   }
+
+  return NULL;
 }

--- a/modules/localgov_alert_banner_full_page/localgov_alert_banner_full_page.module
+++ b/modules/localgov_alert_banner_full_page/localgov_alert_banner_full_page.module
@@ -5,12 +5,14 @@
  * Hook implementations.
  */
 
+declare(strict_types=1);
+
 use Drupal\Component\Utility\Html;
 
 /**
  * Implements hook_theme().
  */
-function localgov_alert_banner_full_page_theme() {
+function localgov_alert_banner_full_page_theme(): array {
   $theme = [];
 
   $theme['localgov_alert_banner__localgov_full_page'] = [
@@ -26,7 +28,7 @@ function localgov_alert_banner_full_page_theme() {
  * - Adds a unique id for the top level wrapper div of the alert banner.
  * - Adds relevant Javascript settings and library.
  */
-function localgov_alert_banner_full_page_preprocess_localgov_alert_banner__localgov_full_page(&$variables) {
+function localgov_alert_banner_full_page_preprocess_localgov_alert_banner__localgov_full_page(&$variables): void {
   $alert_banner_id = $variables['attributes']['id'] ?? Html::getUniqueId('localgov-full-page-alert-banner');
   $variables['attributes']['id'] = $alert_banner_id;
 

--- a/src/Access/AlertBannerEntityPageAccess.php
+++ b/src/Access/AlertBannerEntityPageAccess.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner\Access;
 
 use Drupal\Core\Access\AccessResult;
@@ -18,7 +20,7 @@ class AlertBannerEntityPageAccess implements AccessInterface {
   /**
    * {@inheritDoc}
    */
-  public function access(AccountInterface $account, RouteMatchInterface $route_match) {
+  public function access(AccountInterface $account, RouteMatchInterface $route_match): mixed {
 
     if ($account->hasPermission('view all localgov alert banner entity pages')) {
       return AccessResult::allowed();

--- a/src/AlertBannerEntityAccessControlHandler.php
+++ b/src/AlertBannerEntityAccessControlHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner;
 
 use Drupal\Core\Access\AccessResult;

--- a/src/AlertBannerEntityHtmlRouteProvider.php
+++ b/src/AlertBannerEntityHtmlRouteProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner;
 
 use Drupal\Core\Entity\EntityTypeInterface;

--- a/src/AlertBannerEntityListBuilder.php
+++ b/src/AlertBannerEntityListBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner;
 
 use Drupal\Core\Entity\EntityInterface;

--- a/src/AlertBannerEntityPermissions.php
+++ b/src/AlertBannerEntityPermissions.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
@@ -39,7 +41,7 @@ class AlertBannerEntityPermissions implements ContainerInjectionInterface {
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container): static {
     return new static($container->get('entity_type.manager'));
   }
 

--- a/src/AlertBannerEntityStorage.php
+++ b/src/AlertBannerEntityStorage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner;
 
 use Drupal\Core\Entity\Sql\SqlContentEntityStorage;
@@ -48,7 +50,7 @@ class AlertBannerEntityStorage extends SqlContentEntityStorage implements AlertB
   /**
    * {@inheritdoc}
    */
-  public function clearRevisionsLanguage(LanguageInterface $language) {
+  public function clearRevisionsLanguage(LanguageInterface $language): int|null {
     return $this->database->update('localgov_alert_banner_revision')
       ->fields(['langcode' => LanguageInterface::LANGCODE_NOT_SPECIFIED])
       ->condition('langcode', $language->getId())

--- a/src/AlertBannerEntityStorageInterface.php
+++ b/src/AlertBannerEntityStorageInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner;
 
 use Drupal\Core\Entity\ContentEntityStorageInterface;
@@ -56,6 +58,6 @@ interface AlertBannerEntityStorageInterface extends ContentEntityStorageInterfac
    * @param \Drupal\Core\Language\LanguageInterface $language
    *   The language object.
    */
-  public function clearRevisionsLanguage(LanguageInterface $language);
+  public function clearRevisionsLanguage(LanguageInterface $language): int|null;
 
 }

--- a/src/AlertBannerEntityTranslationHandler.php
+++ b/src/AlertBannerEntityTranslationHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner;
 
 use Drupal\content_translation\ContentTranslationHandler;

--- a/src/AlertBannerEntityTypeListBuilder.php
+++ b/src/AlertBannerEntityTypeListBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner;
 
 use Drupal\Core\Config\Entity\ConfigEntityListBuilder;

--- a/src/Controller/AlertBannerEntityController.php
+++ b/src/Controller/AlertBannerEntityController.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\localgov_alert_banner\Entity\AlertBannerEntityInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -41,7 +44,7 @@ class AlertBannerEntityController extends ControllerBase implements ContainerInj
   /**
    * Publish or Unpublish title for alert banner status change form.
    */
-  public function getStatusFormTitle(AlertBannerEntityInterface $localgov_alert_banner) {
+  public function getStatusFormTitle(AlertBannerEntityInterface $localgov_alert_banner): TranslatableMarkup {
     return $localgov_alert_banner->isPublished() ? $this->t('Remove banner') : $this->t('Put banner live');
   }
 

--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -209,7 +209,7 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
   /**
    * {@inheritdoc}
    */
-  public function getToken(): string {
+  public function getToken(): string|null {
     return $this->get('token')->value;
   }
 

--- a/src/Entity/AlertBannerEntity.php
+++ b/src/Entity/AlertBannerEntity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner\Entity;
 
 use Drupal\Core\Cache\Cache;
@@ -100,7 +102,7 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
   /**
    * {@inheritdoc}
    */
-  public static function preCreate(EntityStorageInterface $storage_controller, array &$values) {
+  public static function preCreate(EntityStorageInterface $storage_controller, array &$values): void {
     parent::preCreate($storage_controller, $values);
     $values += [
       'uid' => \Drupal::currentUser()->id(),
@@ -134,7 +136,7 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
   /**
    * {@inheritdoc}
    */
-  public function preSave(EntityStorageInterface $storage) {
+  public function preSave(EntityStorageInterface $storage): void {
     parent::preSave($storage);
 
     foreach (array_keys($this->getTranslationLanguages()) as $langcode) {
@@ -165,7 +167,7 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
   /**
    * {@inheritdoc}
    */
-  public function postSave(EntityStorageInterface $storage, $update = TRUE) {
+  public function postSave(EntityStorageInterface $storage, $update = TRUE): void {
     parent::postSave($storage, $update);
 
     // Needed by the entity.localgov_alert_banner.status_form route to function
@@ -207,14 +209,14 @@ class AlertBannerEntity extends EditorialContentEntityBase implements AlertBanne
   /**
    * {@inheritdoc}
    */
-  public function getToken() {
+  public function getToken(): string {
     return $this->get('token')->value;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function setToken($token) {
+  public function setToken($token): static {
     $this->set('token', $token);
     return $this;
   }

--- a/src/Entity/AlertBannerEntityInterface.php
+++ b/src/Entity/AlertBannerEntityInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner\Entity;
 
 use Drupal\Core\Entity\ContentEntityInterface;

--- a/src/Entity/AlertBannerEntityType.php
+++ b/src/Entity/AlertBannerEntityType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner\Entity;
 
 use Drupal\Core\Config\Entity\ConfigEntityBundleBase;
@@ -69,7 +71,7 @@ class AlertBannerEntityType extends ConfigEntityBundleBase implements AlertBanne
   /**
    * {@inheritdoc}
    */
-  public function postSave(EntityStorageInterface $storage, $update = TRUE) {
+  public function postSave(EntityStorageInterface $storage, $update = TRUE): void {
 
     // Add fields and workflow when creating a new alert banner type.
     if (!$update && !$this->isSyncing) {

--- a/src/Entity/AlertBannerEntityTypeInterface.php
+++ b/src/Entity/AlertBannerEntityTypeInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner\Entity;
 
 use Drupal\Core\Config\Entity\ConfigEntityInterface;

--- a/src/Entity/AlertBannerEntityViewsData.php
+++ b/src/Entity/AlertBannerEntityViewsData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner\Entity;
 
 use Drupal\views\EntityViewsData;

--- a/src/Form/AlertBannerEntityForm.php
+++ b/src/Form/AlertBannerEntityForm.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner\Form;
 
 use Drupal\Core\Entity\ContentEntityForm;
@@ -52,7 +54,7 @@ class AlertBannerEntityForm extends ContentEntityForm {
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container): static {
     // Instantiates this form class.
     $instance = parent::create($container);
     $instance->account = $container->get('current_user');

--- a/src/Form/AlertBannerEntityRevisionDeleteForm.php
+++ b/src/Form/AlertBannerEntityRevisionDeleteForm.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner\Form;
 
 use Drupal\Core\Form\ConfirmFormBase;
@@ -46,7 +48,7 @@ class AlertBannerEntityRevisionDeleteForm extends ConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container): static {
     $instance = parent::create($container);
     $instance->alertBannerEntityStorage = $container->get('entity_type.manager')->getStorage('localgov_alert_banner');
     $instance->connection = $container->get('database');
@@ -97,7 +99,7 @@ class AlertBannerEntityRevisionDeleteForm extends ConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function submitForm(array &$form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
     // @phpstan-ignore-next-line.
     $this->alertBannerEntityStorage->deleteRevision($this->revision->getRevisionId());
 

--- a/src/Form/AlertBannerEntityRevisionRevertForm.php
+++ b/src/Form/AlertBannerEntityRevisionRevertForm.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner\Form;
 
 use Drupal\Core\Form\ConfirmFormBase;
@@ -46,7 +48,7 @@ class AlertBannerEntityRevisionRevertForm extends ConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container): static {
     $instance = parent::create($container);
     $instance->alertBannerEntityStorage = $container->get('entity_type.manager')->getStorage('localgov_alert_banner');
     $instance->dateFormatter = $container->get('date.formatter');
@@ -104,7 +106,7 @@ class AlertBannerEntityRevisionRevertForm extends ConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function submitForm(array &$form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
     // The revision timestamp will be updated when the revision is saved. Keep
     // the original one for the confirmation message.
     $original_revision_timestamp = $this->revision->getRevisionCreationTime();

--- a/src/Form/AlertBannerEntityRevisionRevertTranslationForm.php
+++ b/src/Form/AlertBannerEntityRevisionRevertTranslationForm.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner\Form;
 
 use Drupal\Core\Form\FormStateInterface;
@@ -37,7 +39,7 @@ class AlertBannerEntityRevisionRevertTranslationForm extends AlertBannerEntityRe
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container): static {
     $instance = parent::create($container);
     $instance->languageManager = $container->get('language_manager');
     $instance->dateTime = $container->get('datetime.time');

--- a/src/Form/AlertBannerEntityStatusForm.php
+++ b/src/Form/AlertBannerEntityStatusForm.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner\Form;
 
 use Drupal\Core\Entity\ContentEntityConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\localgov_alert_banner\Entity\AlertBannerEntity;
 use Drupal\localgov_alert_banner\Entity\AlertBannerEntityInterface;
 
@@ -84,7 +87,7 @@ class AlertBannerEntityStatusForm extends ContentEntityConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function submitForm(array &$form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
     $entity = $this->getEntity();
     assert($entity instanceof AlertBannerEntityInterface);
 
@@ -137,7 +140,7 @@ class AlertBannerEntityStatusForm extends ContentEntityConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  protected function getStatusChangedMessage() {
+  protected function getStatusChangedMessage(): TranslatableMarkup {
     $entity = $this->getEntity();
     assert($entity instanceof AlertBannerEntityInterface);
 
@@ -155,7 +158,7 @@ class AlertBannerEntityStatusForm extends ContentEntityConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  protected function logStatusChanged() {
+  protected function logStatusChanged(): void {
     $entity = $this->getEntity();
     assert($entity instanceof AlertBannerEntityInterface);
 

--- a/src/Form/AlertBannerEntityTypeDeleteForm.php
+++ b/src/Form/AlertBannerEntityTypeDeleteForm.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner\Form;
 
 use Drupal\Core\Entity\EntityConfirmFormBase;
@@ -35,7 +37,7 @@ class AlertBannerEntityTypeDeleteForm extends EntityConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function submitForm(array &$form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
     $this->entity->delete();
 
     $this->messenger()->addMessage(

--- a/src/Form/AlertBannerEntityTypeForm.php
+++ b/src/Form/AlertBannerEntityTypeForm.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner\Form;
 
 use Drupal\Core\Entity\EntityForm;
@@ -13,7 +15,7 @@ class AlertBannerEntityTypeForm extends EntityForm {
   /**
    * {@inheritdoc}
    */
-  public function form(array $form, FormStateInterface $form_state) {
+  public function form(array $form, FormStateInterface $form_state): array {
     $form = parent::form($form, $form_state);
 
     $localgov_alert_banner_type = $this->entity;

--- a/src/Plugin/Block/AlertBannerBlock.php
+++ b/src/Plugin/Block/AlertBannerBlock.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
@@ -143,7 +145,7 @@ class AlertBannerBlock extends BlockBase implements ContainerFactoryPluginInterf
   /**
    * {@inheritdoc}
    */
-  public function blockSubmit($form, FormStateInterface $form_state) {
+  public function blockSubmit($form, FormStateInterface $form_state): void {
     parent::blockSubmit($form, $form_state);
     $values = $form_state->getValues();
     $this->configuration['include_types'] = $values['include_types'];

--- a/src/Plugin/Menu/LocalTask/StatusFormTab.php
+++ b/src/Plugin/Menu/LocalTask/StatusFormTab.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner\Plugin\Menu\LocalTask;
 
 use Drupal\Core\Menu\LocalTaskDefault;

--- a/src/Plugin/views/field/StatusPageLink.php
+++ b/src/Plugin/views/field/StatusPageLink.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner\Plugin\views\field;
 
 use Drupal\Core\Form\FormStateInterface;
@@ -30,7 +32,7 @@ class StatusPageLink extends LinkBase {
   /**
    * {@inheritdoc}
    */
-  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+  public function buildOptionsForm(&$form, FormStateInterface $form_state): void {
     $form['publish_text'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Publish text to display'),

--- a/src/Routing/AlertBannerRouteSubscriber.php
+++ b/src/Routing/AlertBannerRouteSubscriber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\localgov_alert_banner\Routing;
 
 use Drupal\Core\Routing\RouteSubscriberBase;
@@ -13,7 +15,7 @@ class AlertBannerRouteSubscriber extends RouteSubscriberBase {
   /**
    * {@inheritdoc}
    */
-  protected function alterRoutes(RouteCollection $collection) {
+  protected function alterRoutes(RouteCollection $collection): void {
 
     if ($route = $collection->get('entity.localgov_alert_banner.canonical')) {
       // Change the access permission for the alert banner access page.

--- a/tests/src/Functional/AdminViewTest.php
+++ b/tests/src/Functional/AdminViewTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\localgov_alert_banner\Functional;
 
 use Drupal\Core\Url;
@@ -45,7 +47,7 @@ class AdminViewTest extends BrowserTestBase {
   /**
    * Test load the alert banner admin view.
    */
-  public function testLoadAdminView() {
+  public function testLoadAdminView(): void {
     $this->drupalLogin($this->adminUser);
 
     // Check can access the admin view dashboard.

--- a/tests/src/Functional/AlertBannerBlockTest.php
+++ b/tests/src/Functional/AlertBannerBlockTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\localgov_alert_banner\Functional;
 
 use Drupal\Tests\BrowserTestBase;
@@ -60,7 +62,7 @@ class AlertBannerBlockTest extends BrowserTestBase {
    * @param array $newSettings
    *   The new settings to merge with the existing settings.
    */
-  protected function updateBlockSettings(Block $block, array $newSettings) {
+  protected function updateBlockSettings(Block $block, array $newSettings): void {
     $settings = $block->get('settings');
     $block->set('settings', $newSettings + $settings);
     $block->save();
@@ -69,7 +71,7 @@ class AlertBannerBlockTest extends BrowserTestBase {
   /**
    * Test alert banner block displays.
    */
-  public function testAlertBannerDisplays() {
+  public function testAlertBannerDisplays(): void {
     $this->placeAlterBlock();
     // Set up an alert banner.
     $title = $this->randomMachineName(8);
@@ -101,7 +103,7 @@ class AlertBannerBlockTest extends BrowserTestBase {
   /**
    * Test non live alert banner does not display.
    */
-  public function testNonLiveAlertBannerDoesNotDisplay() {
+  public function testNonLiveAlertBannerDoesNotDisplay(): void {
     $this->placeAlterBlock();
     // Set up an alert banner.
     $title = $this->randomMachineName(8);
@@ -125,7 +127,7 @@ class AlertBannerBlockTest extends BrowserTestBase {
   /**
    * Test display title option.
    */
-  public function testAlertDisplayTitle() {
+  public function testAlertDisplayTitle(): void {
     $this->placeAlterBlock();
     $title = $this->randomMachineName(8);
     $alert_message = 'Alert message: ' . $this->randomMachineName(16);
@@ -154,7 +156,7 @@ class AlertBannerBlockTest extends BrowserTestBase {
   /**
    * Test remove hide link option.
    */
-  public function testAlertRemoveHideLink() {
+  public function testAlertRemoveHideLink(): void {
     $this->placeAlterBlock();
     $title = $this->randomMachineName(8);
     $alert_message = 'Alert message: ' . $this->randomMachineName(16);
@@ -184,7 +186,7 @@ class AlertBannerBlockTest extends BrowserTestBase {
   /**
    * Test types display option.
    */
-  public function testAlertBannerTypeDisplay() {
+  public function testAlertBannerTypeDisplay(): void {
     $alterType = $this->container->get('entity_type.manager')
       ->getStorage('localgov_alert_banner_type')
       ->create(['id' => 'extra_type', 'label' => 'Extra type']);

--- a/tests/src/Functional/AlertConfirmationTest.php
+++ b/tests/src/Functional/AlertConfirmationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\localgov_alert_banner\Functional;
 
 use Drupal\Core\Url;
@@ -40,7 +42,7 @@ class AlertConfirmationTest extends BrowserTestBase {
   /**
    * Test alert banner publish un/publish confirmation.
    */
-  public function testAlertConfirmation() {
+  public function testAlertConfirmation(): void {
     // Set up an alert banner.
     $title = $this->randomMachineName(8);
     $alert_message = 'Alert message: ' . $this->randomMachineName(16);
@@ -105,7 +107,7 @@ class AlertConfirmationTest extends BrowserTestBase {
   /**
    * Test save alert with a state change redirects to the confimation page.
    */
-  public function testSaveAlertRedirect() {
+  public function testSaveAlertRedirect(): void {
 
     // Set up an alert banner.
     $title = $this->randomMachineName(8);

--- a/tests/src/Functional/PermissionsTest.php
+++ b/tests/src/Functional/PermissionsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\localgov_alert_banner\Functional;
 
 use Drupal\Tests\BrowserTestBase;
@@ -84,7 +86,7 @@ class PermissionsTest extends BrowserTestBase {
   /**
    * Test the alert banner user access permissions.
    */
-  public function testAlertBannerUserAccess() {
+  public function testAlertBannerUserAccess(): void {
 
     // Check that anonymous user cannot access to the overview page.
     $this->drupalGet('admin/content/alert-banner');

--- a/tests/src/Functional/TranslationsTest.php
+++ b/tests/src/Functional/TranslationsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\localgov_alert_banner\Functional;
 
 use Drupal\Tests\BrowserTestBase;

--- a/tests/src/Functional/ViewsStatusLinkTest.php
+++ b/tests/src/Functional/ViewsStatusLinkTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\localgov_alert_banner\Functional;
 
 use Drupal\Tests\BrowserTestBase;
@@ -56,7 +58,7 @@ class ViewsStatusLinkTest extends BrowserTestBase {
   /**
    * Tests entity link fields.
    */
-  public function testEntityLink() {
+  public function testEntityLink(): void {
     $this->drupalGet('/admin/content/alert-banner');
     $session = $this->assertSession();
 

--- a/tests/src/Functional/VisibilityTest.php
+++ b/tests/src/Functional/VisibilityTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\localgov_alert_banner\Functional;
 
 use Drupal\Tests\BrowserTestBase;
@@ -38,7 +40,7 @@ class VisibilityTest extends BrowserTestBase {
   /**
    * Test the visibility conditions for alert banners.
    */
-  public function testAlertBannerVisibility() {
+  public function testAlertBannerVisibility(): void {
 
     // Create a page for the alert banner.
     $this->createContentType(['type' => 'page']);

--- a/tests/src/FunctionalJavascript/AlertBannerHideTest.php
+++ b/tests/src/FunctionalJavascript/AlertBannerHideTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\localgov_alert_banner\FunctionalJavascript;
 
 use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
@@ -24,7 +26,7 @@ class AlertBannerHideTest extends WebDriverTestBase {
   /**
    * Test alert banner hide link.
    */
-  public function testAlertBannerHide() {
+  public function testAlertBannerHide(): void {
     $this->drupalPlaceBlock('localgov_alert_banner_block');
 
     // Set up an alert banner.

--- a/tests/src/Kernel/AdminViewUrlTest.php
+++ b/tests/src/Kernel/AdminViewUrlTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\localgov_alert_banner\Kernel;
 
 use Drupal\Core\Url;

--- a/tests/src/Kernel/AlertBannerBlockOrderTest.php
+++ b/tests/src/Kernel/AlertBannerBlockOrderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\localgov_alert_banner\Kernel;
 
 use Drupal\Core\Block\BlockPluginInterface;
@@ -59,7 +61,7 @@ class AlertBannerBlockOrderTest extends KernelTestBase {
   /**
    * Test alert banner block order.
    */
-  public function testAlertBannerBlockOrder() {
+  public function testAlertBannerBlockOrder(): void {
 
     // Alert details to set.
     $alert_details = [
@@ -169,7 +171,7 @@ class AlertBannerBlockOrderTest extends KernelTestBase {
   /**
    * Test alert banner block order without type of alert.
    */
-  public function testAlertBannerBlockOrderWithoutTypeOfAlert() {
+  public function testAlertBannerBlockOrderWithoutTypeOfAlert(): void {
 
     // Delete type of alert field.
     // This is so we are testing the case where :-

--- a/tests/src/Kernel/AlertBannerBlockOrderTest.php
+++ b/tests/src/Kernel/AlertBannerBlockOrderTest.php
@@ -236,7 +236,7 @@ class AlertBannerBlockOrderTest extends KernelTestBase {
    */
   protected function getBannersFromBlockRenderArray(BlockPluginInterface $plugin_block): array {
     return array_filter($plugin_block->build(), function ($key) {
-      return strpos($key, '#') !== 0;
+      return !(is_string($key) && str_starts_with($key, '#'));
     }, ARRAY_FILTER_USE_KEY);
   }
 

--- a/tests/src/Kernel/SchedulingInstallTest.php
+++ b/tests/src/Kernel/SchedulingInstallTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\localgov_alert_banner\Kernel;
 
 use Drupal\Core\Extension\MissingDependencyException;
@@ -49,7 +51,7 @@ class SchedulingInstallTest extends KernelTestBase {
   /**
    * Check alert banners are configured when enabling scheduled transitions.
    */
-  public function testEnableScheduledTransitions() {
+  public function testEnableScheduledTransitions(): void {
     \Drupal::service('module_installer')->install(['localgov_alert_banner']);
 
     // Add extra alert banner type.
@@ -97,7 +99,7 @@ class SchedulingInstallTest extends KernelTestBase {
   /**
    * Check scheduled transitions are configured when enabling alert banners.
    */
-  public function testEnableLocalGovAlertBanner() {
+  public function testEnableLocalGovAlertBanner(): void {
     try {
       \Drupal::service('module_installer')->install(['scheduled_transitions']);
     }

--- a/tests/src/Kernel/SchedulingTest.php
+++ b/tests/src/Kernel/SchedulingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\localgov_alert_banner\Kernel;
 
 use Drupal\Core\Extension\MissingDependencyException;
@@ -62,7 +64,7 @@ class SchedulingTest extends KernelTestBase {
   /**
    * Test scheduling alert banners.
    */
-  public function testAlertBannerScheduling() {
+  public function testAlertBannerScheduling(): void {
     // It should be possible to enable scheduled_transitions by listing it in
     // the class $modules array and then add a '@requires module
     // scheduled_transitions' annotation to skip the test if scheduled


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

This fixes the return types that we had in the PHPStan baseline file as well as introducting the strict types declaration